### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/topaxi/tlang/security/code-scanning/5](https://github.com/topaxi/tlang/security/code-scanning/5)

To fix the problem, explicitly specify the minimal necessary permissions for the `build` job. Since the steps in this job are only concerned with checking out the repository, caching dependencies, building, and uploading build artifacts (using the `actions/upload-pages-artifact@v4`), the only permission typically required is `contents: read`. This restricts the `GITHUB_TOKEN` to read-only access to contents, preventing accidental write operations to the repository.

The best way to fix the problem is to add a `permissions` block to the `build` job (line 15), directly under or above `runs-on: ubuntu-latest`, with the following contents:
```yaml
permissions:
  contents: read
```
No changes to imports, methods, or other regions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
