### PR TITLE
feat(typecheck): add two-phase local inference

### DIFF
--- a/crates/tlang_typeck/src/lib.rs
+++ b/crates/tlang_typeck/src/lib.rs
@@ -2,6 +2,7 @@ pub mod builtin_methods;
 pub mod builtin_protocols;
 pub mod builtin_types;
 pub mod builtins;
+mod local_inference;
 mod type_checker;
 mod type_error;
 mod type_table;

--- a/crates/tlang_typeck/src/local_inference.rs
+++ b/crates/tlang_typeck/src/local_inference.rs
@@ -6,6 +6,28 @@ use tlang_span::{HirId, Span, TypeVarId, TypeVarIdAllocator};
 
 use crate::unification::{UnificationError, UnificationTable};
 
+/// Compute the coerced (widened) result type for an arithmetic operation between two
+/// numeric primitive types, matching the main type-checker's `coerced_numeric_result`
+/// semantics.
+fn coerced_numeric_result(lhs: PrimTy, rhs: PrimTy) -> Option<PrimTy> {
+    if !lhs.is_numeric() || !rhs.is_numeric() {
+        return None;
+    }
+    if lhs == rhs {
+        return Some(lhs);
+    }
+    if lhs.is_float() || rhs.is_float() {
+        return Some(PrimTy::F64);
+    }
+    if lhs.is_signed_integer() && rhs.is_signed_integer() {
+        return Some(PrimTy::I64);
+    }
+    if lhs.is_unsigned_integer() && rhs.is_unsigned_integer() {
+        return Some(PrimTy::U64);
+    }
+    Some(PrimTy::F64)
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct LocalBindingSeed {
     pub(crate) type_var_id: TypeVarId,
@@ -69,7 +91,20 @@ impl LocalInferenceScope {
             table.register(seed.type_var_id);
         }
 
+        // Collect arithmetic widening hints in a separate pass to avoid spurious
+        // conflicts from equality-style unification of mixed numeric operands.
+        // These are applied *after* equality constraints so explicit annotations
+        // and assignment constraints take priority.
+        let widening_hints = self.collect_block_widening_hints(block);
+
         self.collect_block_constraints(block, expected_return, &mut table)?;
+
+        // Apply widening hints collected from arithmetic operations. Suppress
+        // conflicts: if a var is already bound by an explicit annotation or
+        // assignment, the annotation wins.
+        for (&var_id, &prim) in &widening_hints {
+            let _ = table.unify_var_ty(var_id, &TyKind::Primitive(prim));
+        }
 
         self.solved_by_binding.clear();
         for (&binding_hir_id, seed) in &self.seeds_by_binding {
@@ -228,7 +263,7 @@ impl LocalInferenceScope {
         table: &mut UnificationTable,
     ) -> Result<(), LocalInferenceError> {
         for stmt in &block.stmts {
-            self.collect_stmt_constraints(stmt, table)?;
+            self.collect_stmt_constraints(stmt, expected_return, table)?;
         }
 
         if let Some(expr) = &block.expr {
@@ -244,6 +279,7 @@ impl LocalInferenceScope {
     fn collect_stmt_constraints(
         &self,
         stmt: &hir::Stmt,
+        expected_return: Option<&TyKind>,
         table: &mut UnificationTable,
     ) -> Result<(), LocalInferenceError> {
         match &stmt.kind {
@@ -260,7 +296,12 @@ impl LocalInferenceScope {
                 self.constrain_expr_to_type(expr, &ty.kind, stmt.span, table)?;
             }
             hir::StmtKind::Expr(expr) => self.collect_expr_constraints(expr, table)?,
-            hir::StmtKind::Return(Some(expr)) => self.collect_expr_constraints(expr, table)?,
+            hir::StmtKind::Return(Some(expr)) => {
+                self.collect_expr_constraints(expr, table)?;
+                if let Some(ret_ty) = expected_return {
+                    self.constrain_expr_to_type(expr, ret_ty, expr.span, table)?;
+                }
+            }
             hir::StmtKind::FunctionDeclaration(_)
             | hir::StmtKind::DynFunctionDeclaration(_)
             | hir::StmtKind::EnumDeclaration(_)
@@ -323,14 +364,16 @@ impl LocalInferenceScope {
                             self.constrain_local_from_completions(var, rhs, expr.span, table)?;
                         }
                     }
+                    // Arithmetic ops are handled via widening hints (see
+                    // collect_block_widening_hints), not direct equality unification,
+                    // to avoid spurious conflicts when mixed numeric types appear in
+                    // the same expression (e.g. i64 + f64 → f64).
                     BinaryOpKind::Add
                     | BinaryOpKind::Sub
                     | BinaryOpKind::Mul
                     | BinaryOpKind::Div
                     | BinaryOpKind::Mod
-                    | BinaryOpKind::Exp => {
-                        self.constrain_numeric_pair(lhs, rhs, expr.span, table)?;
-                    }
+                    | BinaryOpKind::Exp => {}
                     _ => {}
                 }
             }
@@ -377,28 +420,227 @@ impl LocalInferenceScope {
         Ok(())
     }
 
-    fn constrain_numeric_pair(
+    /// Collect widening hints for arithmetic binary operations in a block.
+    ///
+    /// For each seeded local var that appears as an operand in an arithmetic op
+    /// (`+`, `-`, `*`, `/`, `%`, `**`), we record the coerced (widened) numeric
+    /// result type based on the var's default type and the other operand's
+    /// concrete type.  Widening is monotone: if the same var appears in multiple
+    /// arithmetic ops, we keep the widest seen type.
+    ///
+    /// These hints are applied *after* equality constraints so that explicit
+    /// annotations always take priority.
+    fn collect_block_widening_hints(&self, block: &hir::Block) -> HashMap<TypeVarId, PrimTy> {
+        let mut hints = HashMap::new();
+        for stmt in &block.stmts {
+            self.collect_stmt_widening_hints(stmt, &mut hints);
+        }
+        if let Some(expr) = &block.expr {
+            self.collect_expr_widening_hints(expr, &mut hints);
+        }
+        hints
+    }
+
+    fn collect_stmt_widening_hints(
+        &self,
+        stmt: &hir::Stmt,
+        hints: &mut HashMap<TypeVarId, PrimTy>,
+    ) {
+        match &stmt.kind {
+            hir::StmtKind::Let(_, expr, _) | hir::StmtKind::Const(_, _, expr, _) => {
+                self.collect_expr_widening_hints(expr, hints);
+            }
+            hir::StmtKind::Expr(expr) | hir::StmtKind::Return(Some(expr)) => {
+                self.collect_expr_widening_hints(expr, hints);
+            }
+            hir::StmtKind::FunctionDeclaration(_)
+            | hir::StmtKind::DynFunctionDeclaration(_)
+            | hir::StmtKind::EnumDeclaration(_)
+            | hir::StmtKind::StructDeclaration(_)
+            | hir::StmtKind::ProtocolDeclaration(_)
+            | hir::StmtKind::ImplBlock(_)
+            | hir::StmtKind::Return(None) => {}
+        }
+    }
+
+    fn collect_expr_widening_hints(
+        &self,
+        expr: &hir::Expr,
+        hints: &mut HashMap<TypeVarId, PrimTy>,
+    ) {
+        match &expr.kind {
+            hir::ExprKind::Block(block) | hir::ExprKind::Loop(block) => {
+                for stmt in &block.stmts {
+                    self.collect_stmt_widening_hints(stmt, hints);
+                }
+                if let Some(inner) = &block.expr {
+                    self.collect_expr_widening_hints(inner, hints);
+                }
+            }
+            hir::ExprKind::IfElse(condition, then_block, else_clauses) => {
+                self.collect_expr_widening_hints(condition, hints);
+                for stmt in &then_block.stmts {
+                    self.collect_stmt_widening_hints(stmt, hints);
+                }
+                if let Some(inner) = &then_block.expr {
+                    self.collect_expr_widening_hints(inner, hints);
+                }
+                for clause in else_clauses {
+                    if let Some(cond) = &clause.condition {
+                        self.collect_expr_widening_hints(cond, hints);
+                    }
+                    for stmt in &clause.consequence.stmts {
+                        self.collect_stmt_widening_hints(stmt, hints);
+                    }
+                    if let Some(inner) = &clause.consequence.expr {
+                        self.collect_expr_widening_hints(inner, hints);
+                    }
+                }
+            }
+            hir::ExprKind::Match(scrutinee, arms) => {
+                self.collect_expr_widening_hints(scrutinee, hints);
+                for arm in arms {
+                    if let Some(guard) = &arm.guard {
+                        self.collect_expr_widening_hints(guard, hints);
+                    }
+                    for stmt in &arm.block.stmts {
+                        self.collect_stmt_widening_hints(stmt, hints);
+                    }
+                    if let Some(inner) = &arm.block.expr {
+                        self.collect_expr_widening_hints(inner, hints);
+                    }
+                }
+            }
+            hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) => {
+                self.collect_expr_widening_hints(&call.callee, hints);
+                for arg in &call.arguments {
+                    self.collect_expr_widening_hints(arg, hints);
+                }
+            }
+            hir::ExprKind::Binary(op, lhs, rhs) => {
+                self.collect_expr_widening_hints(lhs, hints);
+                self.collect_expr_widening_hints(rhs, hints);
+
+                if matches!(
+                    op,
+                    BinaryOpKind::Add
+                        | BinaryOpKind::Sub
+                        | BinaryOpKind::Mul
+                        | BinaryOpKind::Div
+                        | BinaryOpKind::Mod
+                        | BinaryOpKind::Exp
+                ) {
+                    self.accumulate_numeric_widening_from_pair(lhs, rhs, hints);
+                }
+            }
+            hir::ExprKind::Unary(_, operand)
+            | hir::ExprKind::Cast(operand, _)
+            | hir::ExprKind::TryCast(operand, _)
+            | hir::ExprKind::Break(Some(operand))
+            | hir::ExprKind::FieldAccess(operand, _)
+            | hir::ExprKind::Implements(operand, _)
+            | hir::ExprKind::Let(_, operand) => self.collect_expr_widening_hints(operand, hints),
+            hir::ExprKind::IndexAccess(base, index) => {
+                self.collect_expr_widening_hints(base, hints);
+                self.collect_expr_widening_hints(index, hints);
+            }
+            hir::ExprKind::Range(range) => {
+                self.collect_expr_widening_hints(&range.start, hints);
+                self.collect_expr_widening_hints(&range.end, hints);
+            }
+            hir::ExprKind::List(elements) => {
+                for element in elements {
+                    self.collect_expr_widening_hints(element, hints);
+                }
+            }
+            hir::ExprKind::Dict(entries) => {
+                for (key, value) in entries {
+                    self.collect_expr_widening_hints(key, hints);
+                    self.collect_expr_widening_hints(value, hints);
+                }
+            }
+            hir::ExprKind::TaggedString { tag, exprs, .. } => {
+                self.collect_expr_widening_hints(tag, hints);
+                for expr in exprs {
+                    self.collect_expr_widening_hints(expr, hints);
+                }
+            }
+            hir::ExprKind::FunctionExpression(_)
+            | hir::ExprKind::Break(None)
+            | hir::ExprKind::Continue
+            | hir::ExprKind::Literal(_)
+            | hir::ExprKind::Path(_)
+            | hir::ExprKind::Wildcard => {}
+        }
+    }
+
+    /// For an arithmetic pair `lhs op rhs`, if one side is a seeded local var and
+    /// the other is a concrete numeric primitive, update the widening hints map to
+    /// reflect the coerced (widened) result type.
+    fn accumulate_numeric_widening_from_pair(
         &self,
         lhs: &hir::Expr,
         rhs: &hir::Expr,
-        span: Span,
-        table: &mut UnificationTable,
-    ) -> Result<(), LocalInferenceError> {
+        hints: &mut HashMap<TypeVarId, PrimTy>,
+    ) {
         let lhs_var = self.local_var_from_expr(lhs);
         let rhs_var = self.local_var_from_expr(rhs);
 
         if let Some(lhs_var) = lhs_var {
-            self.unify_local_with_expr_ty(lhs_var, &rhs.ty.kind, span, table)?;
+            self.accumulate_widening_hint(lhs_var, &rhs.ty.kind, hints);
         }
         if let Some(rhs_var) = rhs_var {
-            self.unify_local_with_expr_ty(rhs_var, &lhs.ty.kind, span, table)?;
+            self.accumulate_widening_hint(rhs_var, &lhs.ty.kind, hints);
         }
 
+        // When both operands are seeded local vars, link them so they share the
+        // same widening class: whichever gets a concrete hint from another use
+        // will propagate the widening to the other.
         if let (Some(lhs_var), Some(rhs_var)) = (lhs_var, rhs_var) {
-            self.unify_local_vars(lhs_var, rhs_var, span, table)?;
+            let lhs_hint = hints.get(&lhs_var).copied();
+            let rhs_hint = hints.get(&rhs_var).copied();
+            match (lhs_hint, rhs_hint) {
+                (Some(lp), Some(rp)) => {
+                    if let Some(widened) = coerced_numeric_result(lp, rp) {
+                        hints.insert(lhs_var, widened);
+                        hints.insert(rhs_var, widened);
+                    }
+                }
+                (Some(lp), None) => {
+                    hints.insert(rhs_var, lp);
+                }
+                (None, Some(rp)) => {
+                    hints.insert(lhs_var, rp);
+                }
+                (None, None) => {}
+            }
+        }
+    }
+
+    /// Compute the coerced numeric type for `local_var op other_ty` using the
+    /// var's seed default type and update the widening hints map monotonically
+    /// (only ever widening, never narrowing).
+    fn accumulate_widening_hint(
+        &self,
+        local_var: TypeVarId,
+        other_ty: &TyKind,
+        hints: &mut HashMap<TypeVarId, PrimTy>,
+    ) {
+        let TyKind::Primitive(other_prim) = other_ty else {
+            return;
+        };
+        if !other_prim.is_numeric() {
+            return;
         }
 
-        Ok(())
+        // Use the other operand's concrete type as the hint, widening
+        // monotonically across multiple arithmetic uses of the same var.
+        // Widening via coerced_numeric_result ensures that if the same var
+        // is used with both i64 and f64, the hint becomes f64 (no conflict).
+        let entry = hints.entry(local_var).or_insert(*other_prim);
+        if let Some(widened) = coerced_numeric_result(*entry, *other_prim) {
+            *entry = widened;
+        }
     }
 
     fn constrain_expr_to_type(

--- a/crates/tlang_typeck/src/local_inference.rs
+++ b/crates/tlang_typeck/src/local_inference.rs
@@ -45,13 +45,13 @@ pub(crate) struct LocalInferenceScope {
 #[derive(Debug, Clone)]
 pub(crate) enum LocalInferenceError {
     Conflict {
-        expected: TyKind,
-        actual: TyKind,
+        expected: Box<TyKind>,
+        actual: Box<TyKind>,
         span: Span,
     },
     InfiniteType {
         type_var: TypeVarId,
-        ty: TyKind,
+        ty: Box<TyKind>,
         span: Span,
     },
 }
@@ -463,6 +463,7 @@ impl LocalInferenceScope {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     fn collect_expr_widening_hints(
         &self,
         expr: &hir::Expr,
@@ -757,8 +758,8 @@ impl LocalInferenceScope {
     fn map_unification_error(&self, err: UnificationError, span: Span) -> LocalInferenceError {
         match err {
             UnificationError::Conflict { left, right } => LocalInferenceError::Conflict {
-                expected: *left,
-                actual: *right,
+                expected: left,
+                actual: right,
                 span,
             },
             UnificationError::OccursCheck(occurs) => {
@@ -770,7 +771,7 @@ impl LocalInferenceScope {
                     .unwrap_or(span);
                 LocalInferenceError::InfiniteType {
                     type_var: occurs.var,
-                    ty: occurs.ty,
+                    ty: Box::new(occurs.ty),
                     span,
                 }
             }

--- a/crates/tlang_typeck/src/local_inference.rs
+++ b/crates/tlang_typeck/src/local_inference.rs
@@ -1,0 +1,552 @@
+use std::collections::HashMap;
+
+use tlang_ast::token::Literal;
+use tlang_hir::{self as hir, BinaryOpKind, PrimTy, TyKind};
+use tlang_span::{HirId, Span, TypeVarId, TypeVarIdAllocator};
+
+use crate::unification::{UnificationError, UnificationTable};
+
+#[derive(Debug, Clone)]
+pub(crate) struct LocalBindingSeed {
+    pub(crate) type_var_id: TypeVarId,
+    pub(crate) default_ty: TyKind,
+    pub(crate) span: Span,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct LocalInferenceScope {
+    seeds_by_binding: HashMap<HirId, LocalBindingSeed>,
+    binding_by_var: HashMap<TypeVarId, HirId>,
+    solved_by_binding: HashMap<HirId, TyKind>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum LocalInferenceError {
+    Conflict {
+        expected: TyKind,
+        actual: TyKind,
+        span: Span,
+    },
+    InfiniteType {
+        type_var: TypeVarId,
+        ty: TyKind,
+        span: Span,
+    },
+}
+
+impl LocalInferenceScope {
+    pub(crate) fn collect(block: &hir::Block, allocator: &mut TypeVarIdAllocator) -> Self {
+        let mut scope = Self::default();
+        scope.collect_block_seeds(block, allocator);
+        scope
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.seeds_by_binding.is_empty()
+    }
+
+    pub(crate) fn seed_type_for_binding(&self, hir_id: HirId) -> Option<TyKind> {
+        if let Some(ty) = self.solved_by_binding.get(&hir_id) {
+            return Some(ty.clone());
+        }
+
+        self.seeds_by_binding
+            .get(&hir_id)
+            .map(|seed| TyKind::Var(seed.type_var_id))
+    }
+
+    pub(crate) fn solve(
+        &mut self,
+        block: &hir::Block,
+        expected_return: Option<&TyKind>,
+    ) -> Result<bool, LocalInferenceError> {
+        if self.is_empty() {
+            return Ok(false);
+        }
+
+        let mut table = UnificationTable::new();
+        for seed in self.seeds_by_binding.values() {
+            table.register(seed.type_var_id);
+        }
+
+        self.collect_block_constraints(block, expected_return, &mut table)?;
+
+        self.solved_by_binding.clear();
+        for (&binding_hir_id, seed) in &self.seeds_by_binding {
+            let solved = table
+                .probe(seed.type_var_id)
+                .map(|ty| table.zonk(&ty))
+                .filter(|ty| !matches!(ty, TyKind::Var(_)))
+                .unwrap_or_else(|| seed.default_ty.clone());
+            self.solved_by_binding.insert(binding_hir_id, solved);
+        }
+
+        Ok(true)
+    }
+
+    pub(crate) fn fallback_to_defaults(&mut self) {
+        self.solved_by_binding.clear();
+        for (&binding_hir_id, seed) in &self.seeds_by_binding {
+            self.solved_by_binding
+                .insert(binding_hir_id, seed.default_ty.clone());
+        }
+    }
+
+    fn collect_block_seeds(&mut self, block: &hir::Block, allocator: &mut TypeVarIdAllocator) {
+        for stmt in &block.stmts {
+            self.collect_stmt_seeds(stmt, allocator);
+        }
+        if let Some(expr) = &block.expr {
+            self.collect_expr_seeds(expr, allocator);
+        }
+    }
+
+    fn collect_stmt_seeds(&mut self, stmt: &hir::Stmt, allocator: &mut TypeVarIdAllocator) {
+        match &stmt.kind {
+            hir::StmtKind::Let(pat, expr, ty) | hir::StmtKind::Const(_, pat, expr, ty) => {
+                self.maybe_seed_binding(pat, expr, ty, stmt.span, allocator);
+                self.collect_expr_seeds(expr, allocator);
+            }
+            hir::StmtKind::Expr(expr) => self.collect_expr_seeds(expr, allocator),
+            hir::StmtKind::Return(Some(expr)) => self.collect_expr_seeds(expr, allocator),
+            hir::StmtKind::FunctionDeclaration(_)
+            | hir::StmtKind::DynFunctionDeclaration(_)
+            | hir::StmtKind::EnumDeclaration(_)
+            | hir::StmtKind::StructDeclaration(_)
+            | hir::StmtKind::ProtocolDeclaration(_)
+            | hir::StmtKind::ImplBlock(_)
+            | hir::StmtKind::Return(None) => {}
+        }
+    }
+
+    fn maybe_seed_binding(
+        &mut self,
+        pat: &hir::Pat,
+        expr: &hir::Expr,
+        ty: &hir::Ty,
+        span: Span,
+        allocator: &mut TypeVarIdAllocator,
+    ) {
+        if !matches!(ty.kind, TyKind::Unknown) {
+            return;
+        }
+        let hir::PatKind::Identifier(hir_id, _) = &pat.kind else {
+            return;
+        };
+        let Some(default_ty) = refineable_literal_default_ty(expr) else {
+            return;
+        };
+
+        let type_var_id = allocator.next_id();
+        self.seeds_by_binding.insert(
+            *hir_id,
+            LocalBindingSeed {
+                type_var_id,
+                default_ty,
+                span,
+            },
+        );
+        self.binding_by_var.insert(type_var_id, *hir_id);
+    }
+
+    fn collect_expr_seeds(&mut self, expr: &hir::Expr, allocator: &mut TypeVarIdAllocator) {
+        match &expr.kind {
+            hir::ExprKind::Block(block) | hir::ExprKind::Loop(block) => {
+                self.collect_block_seeds(block, allocator);
+            }
+            hir::ExprKind::IfElse(condition, then_block, else_clauses) => {
+                self.collect_expr_seeds(condition, allocator);
+                self.collect_block_seeds(then_block, allocator);
+                for clause in else_clauses {
+                    if let Some(condition) = &clause.condition {
+                        self.collect_expr_seeds(condition, allocator);
+                    }
+                    self.collect_block_seeds(&clause.consequence, allocator);
+                }
+            }
+            hir::ExprKind::Match(scrutinee, arms) => {
+                self.collect_expr_seeds(scrutinee, allocator);
+                for arm in arms {
+                    if let Some(guard) = &arm.guard {
+                        self.collect_expr_seeds(guard, allocator);
+                    }
+                    self.collect_block_seeds(&arm.block, allocator);
+                }
+            }
+            hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) => {
+                self.collect_expr_seeds(&call.callee, allocator);
+                for arg in &call.arguments {
+                    self.collect_expr_seeds(arg, allocator);
+                }
+            }
+            hir::ExprKind::Binary(_, lhs, rhs) => {
+                self.collect_expr_seeds(lhs, allocator);
+                self.collect_expr_seeds(rhs, allocator);
+            }
+            hir::ExprKind::Unary(_, operand)
+            | hir::ExprKind::Cast(operand, _)
+            | hir::ExprKind::TryCast(operand, _)
+            | hir::ExprKind::Break(Some(operand))
+            | hir::ExprKind::FieldAccess(operand, _)
+            | hir::ExprKind::IndexAccess(operand, _)
+            | hir::ExprKind::Implements(operand, _)
+            | hir::ExprKind::Let(_, operand) => self.collect_expr_seeds(operand, allocator),
+            hir::ExprKind::Range(range) => {
+                self.collect_expr_seeds(&range.start, allocator);
+                self.collect_expr_seeds(&range.end, allocator);
+            }
+            hir::ExprKind::List(elements) => {
+                for element in elements {
+                    self.collect_expr_seeds(element, allocator);
+                }
+            }
+            hir::ExprKind::Dict(entries) => {
+                for (key, value) in entries {
+                    self.collect_expr_seeds(key, allocator);
+                    self.collect_expr_seeds(value, allocator);
+                }
+            }
+            hir::ExprKind::TaggedString { tag, exprs, .. } => {
+                self.collect_expr_seeds(tag, allocator);
+                for expr in exprs {
+                    self.collect_expr_seeds(expr, allocator);
+                }
+            }
+            hir::ExprKind::FunctionExpression(_)
+            | hir::ExprKind::Break(None)
+            | hir::ExprKind::Continue
+            | hir::ExprKind::Literal(_)
+            | hir::ExprKind::Path(_)
+            | hir::ExprKind::Wildcard => {}
+        }
+    }
+
+    fn collect_block_constraints(
+        &self,
+        block: &hir::Block,
+        expected_return: Option<&TyKind>,
+        table: &mut UnificationTable,
+    ) -> Result<(), LocalInferenceError> {
+        for stmt in &block.stmts {
+            self.collect_stmt_constraints(stmt, table)?;
+        }
+
+        if let Some(expr) = &block.expr {
+            if let Some(expected_return) = expected_return {
+                self.constrain_expr_to_type(expr, expected_return, expr.span, table)?;
+            }
+            self.collect_expr_constraints(expr, table)?;
+        }
+
+        Ok(())
+    }
+
+    fn collect_stmt_constraints(
+        &self,
+        stmt: &hir::Stmt,
+        table: &mut UnificationTable,
+    ) -> Result<(), LocalInferenceError> {
+        match &stmt.kind {
+            hir::StmtKind::Let(pat, expr, ty) | hir::StmtKind::Const(_, pat, expr, ty) => {
+                if let hir::PatKind::Identifier(binding_hir_id, _) = &pat.kind
+                    && let Some(seed) = self.seeds_by_binding.get(binding_hir_id)
+                    && is_constraining_ty(&ty.kind)
+                {
+                    table
+                        .unify_var_ty(seed.type_var_id, &ty.kind)
+                        .map_err(|err| self.map_unification_error(err, stmt.span))?;
+                }
+                self.collect_expr_constraints(expr, table)?;
+                self.constrain_expr_to_type(expr, &ty.kind, stmt.span, table)?;
+            }
+            hir::StmtKind::Expr(expr) => self.collect_expr_constraints(expr, table)?,
+            hir::StmtKind::Return(Some(expr)) => self.collect_expr_constraints(expr, table)?,
+            hir::StmtKind::FunctionDeclaration(_)
+            | hir::StmtKind::DynFunctionDeclaration(_)
+            | hir::StmtKind::EnumDeclaration(_)
+            | hir::StmtKind::StructDeclaration(_)
+            | hir::StmtKind::ProtocolDeclaration(_)
+            | hir::StmtKind::ImplBlock(_)
+            | hir::StmtKind::Return(None) => {}
+        }
+
+        Ok(())
+    }
+
+    fn collect_expr_constraints(
+        &self,
+        expr: &hir::Expr,
+        table: &mut UnificationTable,
+    ) -> Result<(), LocalInferenceError> {
+        match &expr.kind {
+            hir::ExprKind::Block(block) | hir::ExprKind::Loop(block) => {
+                self.collect_block_constraints(block, None, table)?;
+            }
+            hir::ExprKind::IfElse(condition, then_block, else_clauses) => {
+                self.collect_expr_constraints(condition, table)?;
+                self.collect_block_constraints(then_block, None, table)?;
+                for clause in else_clauses {
+                    if let Some(condition) = &clause.condition {
+                        self.collect_expr_constraints(condition, table)?;
+                    }
+                    self.collect_block_constraints(&clause.consequence, None, table)?;
+                }
+            }
+            hir::ExprKind::Match(scrutinee, arms) => {
+                self.collect_expr_constraints(scrutinee, table)?;
+                for arm in arms {
+                    if let Some(guard) = &arm.guard {
+                        self.collect_expr_constraints(guard, table)?;
+                    }
+                    self.collect_block_constraints(&arm.block, None, table)?;
+                }
+            }
+            hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) => {
+                self.collect_expr_constraints(&call.callee, table)?;
+                for arg in &call.arguments {
+                    self.collect_expr_constraints(arg, table)?;
+                }
+                if let TyKind::Fn(param_tys, _) = &call.callee.ty.kind {
+                    for (arg, param_ty) in call.arguments.iter().zip(param_tys.iter()) {
+                        self.constrain_expr_to_type(arg, &param_ty.kind, arg.span, table)?;
+                    }
+                }
+            }
+            hir::ExprKind::Binary(op, lhs, rhs) => {
+                self.collect_expr_constraints(lhs, table)?;
+                self.collect_expr_constraints(rhs, table)?;
+
+                match op {
+                    BinaryOpKind::Assign => {
+                        if let Some(var) = self.local_var_from_expr(lhs) {
+                            self.unify_local_with_expr_ty(var, &rhs.ty.kind, expr.span, table)?;
+                            self.constrain_local_from_completions(var, rhs, expr.span, table)?;
+                        }
+                    }
+                    BinaryOpKind::Add
+                    | BinaryOpKind::Sub
+                    | BinaryOpKind::Mul
+                    | BinaryOpKind::Div
+                    | BinaryOpKind::Mod
+                    | BinaryOpKind::Exp => {
+                        self.constrain_numeric_pair(lhs, rhs, expr.span, table)?;
+                    }
+                    _ => {}
+                }
+            }
+            hir::ExprKind::Unary(_, operand)
+            | hir::ExprKind::Cast(operand, _)
+            | hir::ExprKind::TryCast(operand, _)
+            | hir::ExprKind::Break(Some(operand))
+            | hir::ExprKind::FieldAccess(operand, _)
+            | hir::ExprKind::Implements(operand, _)
+            | hir::ExprKind::Let(_, operand) => self.collect_expr_constraints(operand, table)?,
+            hir::ExprKind::IndexAccess(base, index) => {
+                self.collect_expr_constraints(base, table)?;
+                self.collect_expr_constraints(index, table)?;
+            }
+            hir::ExprKind::Range(range) => {
+                self.collect_expr_constraints(&range.start, table)?;
+                self.collect_expr_constraints(&range.end, table)?;
+            }
+            hir::ExprKind::List(elements) => {
+                for element in elements {
+                    self.collect_expr_constraints(element, table)?;
+                }
+            }
+            hir::ExprKind::Dict(entries) => {
+                for (key, value) in entries {
+                    self.collect_expr_constraints(key, table)?;
+                    self.collect_expr_constraints(value, table)?;
+                }
+            }
+            hir::ExprKind::TaggedString { tag, exprs, .. } => {
+                self.collect_expr_constraints(tag, table)?;
+                for expr in exprs {
+                    self.collect_expr_constraints(expr, table)?;
+                }
+            }
+            hir::ExprKind::FunctionExpression(_)
+            | hir::ExprKind::Break(None)
+            | hir::ExprKind::Continue
+            | hir::ExprKind::Literal(_)
+            | hir::ExprKind::Path(_)
+            | hir::ExprKind::Wildcard => {}
+        }
+
+        Ok(())
+    }
+
+    fn constrain_numeric_pair(
+        &self,
+        lhs: &hir::Expr,
+        rhs: &hir::Expr,
+        span: Span,
+        table: &mut UnificationTable,
+    ) -> Result<(), LocalInferenceError> {
+        let lhs_var = self.local_var_from_expr(lhs);
+        let rhs_var = self.local_var_from_expr(rhs);
+
+        if let Some(lhs_var) = lhs_var {
+            self.unify_local_with_expr_ty(lhs_var, &rhs.ty.kind, span, table)?;
+        }
+        if let Some(rhs_var) = rhs_var {
+            self.unify_local_with_expr_ty(rhs_var, &lhs.ty.kind, span, table)?;
+        }
+
+        if let (Some(lhs_var), Some(rhs_var)) = (lhs_var, rhs_var) {
+            self.unify_local_vars(lhs_var, rhs_var, span, table)?;
+        }
+
+        Ok(())
+    }
+
+    fn constrain_expr_to_type(
+        &self,
+        expr: &hir::Expr,
+        expected: &TyKind,
+        span: Span,
+        table: &mut UnificationTable,
+    ) -> Result<(), LocalInferenceError> {
+        if let Some(var) = self.local_var_from_expr(expr) {
+            self.unify_local_with_ty(var, expected, span, table)?;
+        }
+
+        Ok(())
+    }
+
+    fn constrain_local_from_completions(
+        &self,
+        local_var: TypeVarId,
+        expr: &hir::Expr,
+        span: Span,
+        table: &mut UnificationTable,
+    ) -> Result<(), LocalInferenceError> {
+        match &expr.kind {
+            hir::ExprKind::Block(block) | hir::ExprKind::Loop(block) => {
+                if let Some(inner) = &block.expr {
+                    self.constrain_local_from_completions(local_var, inner, span, table)?;
+                }
+            }
+            hir::ExprKind::IfElse(_, then_block, else_clauses) => {
+                if let Some(expr) = &then_block.expr {
+                    self.constrain_local_from_completions(local_var, expr, span, table)?;
+                }
+                for clause in else_clauses {
+                    if let Some(expr) = &clause.consequence.expr {
+                        self.constrain_local_from_completions(local_var, expr, span, table)?;
+                    }
+                }
+            }
+            hir::ExprKind::Match(_, arms) => {
+                for arm in arms {
+                    if let Some(expr) = &arm.block.expr {
+                        self.constrain_local_from_completions(local_var, expr, span, table)?;
+                    }
+                }
+            }
+            hir::ExprKind::Break(Some(value)) => {
+                self.unify_local_with_expr_ty(local_var, &value.ty.kind, span, table)?;
+            }
+            _ => {
+                self.unify_local_with_expr_ty(local_var, &expr.ty.kind, span, table)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn unify_local_with_expr_ty(
+        &self,
+        local_var: TypeVarId,
+        ty: &TyKind,
+        span: Span,
+        table: &mut UnificationTable,
+    ) -> Result<(), LocalInferenceError> {
+        if let Some(other_var) = self.local_var_from_ty(ty) {
+            return self.unify_local_vars(local_var, other_var, span, table);
+        }
+        self.unify_local_with_ty(local_var, ty, span, table)
+    }
+
+    fn unify_local_vars(
+        &self,
+        left: TypeVarId,
+        right: TypeVarId,
+        span: Span,
+        table: &mut UnificationTable,
+    ) -> Result<(), LocalInferenceError> {
+        if left == right {
+            return Ok(());
+        }
+        table
+            .unify_var_var(left, right)
+            .map_err(|err| self.map_unification_error(err, span))
+    }
+
+    fn unify_local_with_ty(
+        &self,
+        local_var: TypeVarId,
+        ty: &TyKind,
+        span: Span,
+        table: &mut UnificationTable,
+    ) -> Result<(), LocalInferenceError> {
+        if !is_constraining_ty(ty) {
+            return Ok(());
+        }
+        table
+            .unify_var_ty(local_var, ty)
+            .map_err(|err| self.map_unification_error(err, span))
+    }
+
+    fn local_var_from_expr(&self, expr: &hir::Expr) -> Option<TypeVarId> {
+        self.local_var_from_ty(&expr.ty.kind)
+    }
+
+    fn local_var_from_ty(&self, ty: &TyKind) -> Option<TypeVarId> {
+        match ty {
+            TyKind::Var(type_var_id) if self.binding_by_var.contains_key(type_var_id) => {
+                Some(*type_var_id)
+            }
+            _ => None,
+        }
+    }
+
+    fn map_unification_error(&self, err: UnificationError, span: Span) -> LocalInferenceError {
+        match err {
+            UnificationError::Conflict { left, right } => LocalInferenceError::Conflict {
+                expected: *left,
+                actual: *right,
+                span,
+            },
+            UnificationError::OccursCheck(occurs) => {
+                let span = self
+                    .binding_by_var
+                    .get(&occurs.var)
+                    .and_then(|binding| self.seeds_by_binding.get(binding))
+                    .map(|seed| seed.span)
+                    .unwrap_or(span);
+                LocalInferenceError::InfiniteType {
+                    type_var: occurs.var,
+                    ty: occurs.ty,
+                    span,
+                }
+            }
+        }
+    }
+}
+
+fn refineable_literal_default_ty(expr: &hir::Expr) -> Option<TyKind> {
+    let hir::ExprKind::Literal(lit) = &expr.kind else {
+        return None;
+    };
+    match lit.as_ref() {
+        Literal::Integer(_) | Literal::UnsignedInteger(_) => Some(TyKind::Primitive(PrimTy::I64)),
+        Literal::Float(_) => Some(TyKind::Primitive(PrimTy::F64)),
+        _ => None,
+    }
+}
+
+fn is_constraining_ty(ty: &TyKind) -> bool {
+    !matches!(ty, TyKind::Unknown | TyKind::Var(_))
+}

--- a/crates/tlang_typeck/src/local_inference.rs
+++ b/crates/tlang_typeck/src/local_inference.rs
@@ -25,6 +25,10 @@ fn coerced_numeric_result(lhs: PrimTy, rhs: PrimTy) -> Option<PrimTy> {
     if lhs.is_unsigned_integer() && rhs.is_unsigned_integer() {
         return Some(PrimTy::U64);
     }
+    // Reach of this fallback: mixed signed/unsigned integer arithmetic (e.g.
+    // i64 + u64).  The language does not have a dedicated "widest integer"
+    // type that covers both, so we conservatively widen to f64, matching the
+    // behaviour of the main type-checker's arithmetic coercion rules.
     Some(PrimTy::F64)
 }
 
@@ -99,9 +103,12 @@ impl LocalInferenceScope {
 
         self.collect_block_constraints(block, expected_return, &mut table)?;
 
-        // Apply widening hints collected from arithmetic operations. Suppress
-        // conflicts: if a var is already bound by an explicit annotation or
-        // assignment, the annotation wins.
+        // Apply widening hints collected from arithmetic operations. These hints
+        // represent the widest concrete numeric type seen as an operand to any
+        // arithmetic op involving the local var. Errors are suppressed: if a var
+        // is already bound by an explicit annotation or assignment constraint
+        // (collected in the earlier collect_block_constraints pass), that binding
+        // wins and the widening hint is simply ignored.
         for (&var_id, &prim) in &widening_hints {
             let _ = table.unify_var_ty(var_id, &TyKind::Primitive(prim));
         }

--- a/crates/tlang_typeck/src/type_checker.rs
+++ b/crates/tlang_typeck/src/type_checker.rs
@@ -3,15 +3,16 @@ use std::collections::HashMap;
 use tlang_ast::node::UnaryOp;
 use tlang_ast::token::Literal;
 use tlang_hir::Visitor;
-use tlang_hir::visit::{walk_block, walk_expr, walk_module, walk_stmt};
+use tlang_hir::visit::{walk_block, walk_expr, walk_stmt};
 use tlang_hir::{self as hir, BinaryOpKind, PrimTy, Ty, TyKind};
 use tlang_hir_opt::hir_opt::{HirOptContext, HirOptError, HirPass};
-use tlang_span::TypeVarId;
+use tlang_span::{TypeVarId, TypeVarIdAllocator};
 
 use crate::builtin_methods;
 use crate::builtin_protocols;
 use crate::builtin_types;
 use crate::builtins;
+use crate::local_inference::{LocalInferenceError, LocalInferenceScope};
 use crate::type_table::{
     AssociatedTypeInfo, EnumInfo, ImplInfo, ProtocolInfo, ProtocolMethodInfo, StructInfo,
     VariantInfo,
@@ -52,13 +53,26 @@ pub struct TypeChecker {
     /// inference for unannotated loop accumulators (e.g. `with sum = 0`
     /// infers `sum: isize` when the iterator yields `isize` items).
     pending_accumulator_type: Option<TyKind>,
+    /// Allocator for checker-local type variables used by two-phase local
+    /// binding inference. Starts well above lowering/builtin ids to avoid
+    /// collisions with generic type parameter vars.
+    local_type_var_id_allocator: TypeVarIdAllocator,
+    /// Stack of active local inference scopes. One scope per executable body
+    /// (module body, function body, closure body).
+    local_inference_scopes: Vec<LocalInferenceScope>,
+    /// Local inference errors are deferred until the surrounding body finishes
+    /// any recheck cycle so provisional-return retries do not discard them.
+    pending_local_inference_errors: Vec<LocalInferenceError>,
 }
 
 impl TypeChecker {
     const MIN_PROTOCOL_PATH_SEGMENTS: usize = 2;
 
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            local_type_var_id_allocator: TypeVarIdAllocator::new(1_000_000),
+            ..Self::default()
+        }
     }
 
     fn current_context(&self) -> TypingContext {
@@ -66,6 +80,241 @@ impl TypeChecker {
             .last()
             .copied()
             .unwrap_or(TypingContext::Permissive)
+    }
+
+    fn current_local_inference_scope(&self) -> Option<&LocalInferenceScope> {
+        self.local_inference_scopes.last()
+    }
+
+    fn local_binding_hir_id(pat: &hir::Pat) -> Option<tlang_span::HirId> {
+        match &pat.kind {
+            hir::PatKind::Identifier(hir_id, _) => Some(*hir_id),
+            _ => None,
+        }
+    }
+
+    fn seed_local_inference_binding_type(&self, pat: &hir::Pat, ty: &mut Ty) {
+        if !matches!(ty.kind, TyKind::Unknown | TyKind::Var(_)) {
+            return;
+        }
+
+        let Some(hir_id) = Self::local_binding_hir_id(pat) else {
+            return;
+        };
+        let Some(seed_ty) = self
+            .current_local_inference_scope()
+            .and_then(|scope| scope.seed_type_for_binding(hir_id))
+        else {
+            return;
+        };
+
+        ty.kind = seed_ty;
+    }
+
+    fn seed_local_inference_literal_expr(&self, pat: &hir::Pat, expr: &mut hir::Expr) {
+        let Some(hir_id) = Self::local_binding_hir_id(pat) else {
+            return;
+        };
+        let Some(seed_ty) = self
+            .current_local_inference_scope()
+            .and_then(|scope| scope.seed_type_for_binding(hir_id))
+        else {
+            return;
+        };
+
+        if matches!(
+            expr.kind,
+            hir::ExprKind::Literal(_)
+                if matches!(expr.ty.kind, TyKind::Unknown | TyKind::Var(_))
+                    || matches!(
+                        expr.ty.kind,
+                        TyKind::Primitive(PrimTy::I64) | TyKind::Primitive(PrimTy::F64)
+                    )
+        ) {
+            expr.ty.kind = seed_ty;
+        }
+    }
+
+    fn report_local_inference_error(&mut self, error: LocalInferenceError) {
+        match error {
+            LocalInferenceError::Conflict {
+                expected,
+                actual,
+                span,
+            } => self.errors.push(TypeError::BindingTypeMismatch {
+                declared: expected.to_string(),
+                actual: actual.to_string(),
+                span,
+            }),
+            LocalInferenceError::InfiniteType { type_var, ty, span } => {
+                self.errors.push(TypeError::InfiniteType {
+                    type_param: type_var.to_string(),
+                    ty: ty.to_string(),
+                    span,
+                });
+            }
+        }
+    }
+
+    fn flush_local_inference_errors(&mut self) {
+        let pending = std::mem::take(&mut self.pending_local_inference_errors);
+        for error in pending {
+            self.report_local_inference_error(error);
+        }
+    }
+
+    fn typecheck_executable_block(
+        &mut self,
+        block: &mut hir::Block,
+        expected_return: Option<TyKind>,
+        error_checkpoint: usize,
+    ) {
+        let scope = LocalInferenceScope::collect(block, &mut self.local_type_var_id_allocator);
+        let has_candidates = !scope.is_empty();
+        self.local_inference_scopes.push(scope);
+
+        if let Some(expected_return) = expected_return.as_ref()
+            && let Some(expr) = &mut block.expr
+        {
+            self.apply_expected_expr_type(expr, expected_return);
+        }
+        self.visit_block(block, &mut ());
+
+        let mut scope = self
+            .local_inference_scopes
+            .pop()
+            .expect("local inference scope should be active for executable block");
+
+        if !has_candidates {
+            return;
+        }
+
+        let local_inference_error = if let Err(error) = scope.solve(block, expected_return.as_ref())
+        {
+            scope.fallback_to_defaults();
+            Some(error)
+        } else {
+            None
+        };
+
+        self.errors.truncate(error_checkpoint);
+        if let Some(observed) = self.observed_return_types.last_mut() {
+            observed.clear();
+        }
+
+        Self::reset_block_expr_types(block);
+        self.local_inference_scopes.push(scope);
+        if let Some(expected_return) = expected_return.as_ref()
+            && let Some(expr) = &mut block.expr
+        {
+            self.apply_expected_expr_type(expr, expected_return);
+        }
+        self.visit_block(block, &mut ());
+        self.local_inference_scopes
+            .pop()
+            .expect("local inference scope should still be active on second pass");
+
+        if let Some(error) = local_inference_error {
+            self.pending_local_inference_errors.push(error);
+        }
+    }
+
+    fn reset_block_expr_types(block: &mut hir::Block) {
+        for stmt in &mut block.stmts {
+            Self::reset_stmt_expr_types(stmt);
+        }
+        if let Some(expr) = &mut block.expr {
+            Self::reset_expr_type(expr);
+        }
+    }
+
+    fn reset_stmt_expr_types(stmt: &mut hir::Stmt) {
+        match &mut stmt.kind {
+            hir::StmtKind::Let(_, expr, _)
+            | hir::StmtKind::Const(_, _, expr, _)
+            | hir::StmtKind::Expr(expr)
+            | hir::StmtKind::Return(Some(expr)) => Self::reset_expr_type(expr),
+            hir::StmtKind::FunctionDeclaration(_)
+            | hir::StmtKind::DynFunctionDeclaration(_)
+            | hir::StmtKind::EnumDeclaration(_)
+            | hir::StmtKind::StructDeclaration(_)
+            | hir::StmtKind::ProtocolDeclaration(_)
+            | hir::StmtKind::ImplBlock(_)
+            | hir::StmtKind::Return(None) => {}
+        }
+    }
+
+    fn reset_expr_type(expr: &mut hir::Expr) {
+        expr.ty = Ty::unknown();
+
+        match &mut expr.kind {
+            hir::ExprKind::Block(block) | hir::ExprKind::Loop(block) => {
+                Self::reset_block_expr_types(block);
+            }
+            hir::ExprKind::Break(Some(value))
+            | hir::ExprKind::Unary(_, value)
+            | hir::ExprKind::Cast(value, _)
+            | hir::ExprKind::TryCast(value, _)
+            | hir::ExprKind::FieldAccess(value, _)
+            | hir::ExprKind::Implements(value, _)
+            | hir::ExprKind::Let(_, value) => Self::reset_expr_type(value),
+            hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) => {
+                Self::reset_expr_type(&mut call.callee);
+                for arg in &mut call.arguments {
+                    Self::reset_expr_type(arg);
+                }
+            }
+            hir::ExprKind::Binary(_, lhs, rhs) | hir::ExprKind::IndexAccess(lhs, rhs) => {
+                Self::reset_expr_type(lhs);
+                Self::reset_expr_type(rhs);
+            }
+            hir::ExprKind::IfElse(condition, then_block, else_clauses) => {
+                Self::reset_expr_type(condition);
+                Self::reset_block_expr_types(then_block);
+                for clause in else_clauses {
+                    if let Some(condition) = &mut clause.condition {
+                        Self::reset_expr_type(condition);
+                    }
+                    Self::reset_block_expr_types(&mut clause.consequence);
+                }
+            }
+            hir::ExprKind::List(elements) => {
+                for element in elements {
+                    Self::reset_expr_type(element);
+                }
+            }
+            hir::ExprKind::Dict(entries) => {
+                for (key, value) in entries {
+                    Self::reset_expr_type(key);
+                    Self::reset_expr_type(value);
+                }
+            }
+            hir::ExprKind::Match(scrutinee, arms) => {
+                Self::reset_expr_type(scrutinee);
+                for arm in arms {
+                    if let Some(guard) = &mut arm.guard {
+                        Self::reset_expr_type(guard);
+                    }
+                    Self::reset_block_expr_types(&mut arm.block);
+                }
+            }
+            hir::ExprKind::Range(range) => {
+                Self::reset_expr_type(&mut range.start);
+                Self::reset_expr_type(&mut range.end);
+            }
+            hir::ExprKind::TaggedString { tag, exprs, .. } => {
+                Self::reset_expr_type(tag);
+                for expr in exprs {
+                    Self::reset_expr_type(expr);
+                }
+            }
+            hir::ExprKind::FunctionExpression(_)
+            | hir::ExprKind::Break(None)
+            | hir::ExprKind::Continue
+            | hir::ExprKind::Literal(_)
+            | hir::ExprKind::Path(_)
+            | hir::ExprKind::Wildcard => {}
+        }
     }
 
     fn iterable_item_type(&self, ty: &TyKind) -> Option<TyKind> {
@@ -90,9 +339,6 @@ impl TypeChecker {
         let hir::PatKind::Identifier(hir_id, ident) = &pat.kind else {
             return;
         };
-        if ident.as_str() != "iterator$$" {
-            return;
-        }
         let hir::ExprKind::Call(call) = &expr.kind else {
             return;
         };
@@ -104,9 +350,11 @@ impl TypeChecker {
         }
         if let Some(item_ty) = self.iterable_item_type(&call.arguments[0].ty.kind) {
             self.iterator_item_types.insert(*hir_id, item_ty.clone());
-            // Store as pending so the next `let accumulator$$` binding can
-            // adopt this type when the accumulator has no outer annotation.
-            self.pending_accumulator_type = Some(item_ty);
+            if ident.as_str() == "iterator$$" {
+                // Store as pending so the next `let accumulator$$` binding can
+                // adopt this type when the accumulator has no outer annotation.
+                self.pending_accumulator_type = Some(item_ty);
+            }
         }
     }
 
@@ -2485,7 +2733,7 @@ impl TypeChecker {
     fn apply_expected_loop_accumulator_type(&mut self, block: &mut hir::Block, expected: &TyKind) {
         fn can_refine_from_expected(kind: &TyKind) -> bool {
             match kind {
-                TyKind::Unknown => true,
+                TyKind::Unknown | TyKind::Var(_) => true,
                 TyKind::List(inner) | TyKind::Slice(inner) => matches!(inner.kind, TyKind::Unknown),
                 TyKind::Dict(key, value) => {
                     matches!(key.kind, TyKind::Unknown) && matches!(value.kind, TyKind::Unknown)
@@ -2536,7 +2784,7 @@ impl TypeChecker {
                 // binding by constant propagation — its type is already concrete
                 // and must be respected (e.g. `let x: i64 = 5; let y: isize = x`
                 // should remain a type mismatch, not silently coerce `5` to `isize`).
-                if !matches!(expr.ty.kind, TyKind::Unknown) {
+                if !matches!(expr.ty.kind, TyKind::Unknown | TyKind::Var(_)) {
                     return;
                 }
                 if matches!(
@@ -2640,13 +2888,11 @@ impl TypeChecker {
         self.return_type_stack.push(decl.return_type.kind.clone());
         self.observed_return_types.push(Vec::new());
         let error_checkpoint = self.errors.len();
-        if !matches!(decl.return_type.kind, TyKind::Unknown)
-            && let Some(expr) = &mut decl.body.expr
-        {
-            self.apply_expected_expr_type(expr, &decl.return_type.kind);
-        }
-        self.visit_block(&mut decl.body, &mut ());
+        let expected_return = (!matches!(decl.return_type.kind, TyKind::Unknown))
+            .then_some(decl.return_type.kind.clone());
+        self.typecheck_executable_block(&mut decl.body, expected_return, error_checkpoint);
         self.recheck_body_with_provisional_return(decl, error_checkpoint);
+        self.flush_local_inference_errors();
 
         // Check that the closure body type matches the declared return type.
         self.check_function_body_return(decl);
@@ -2725,13 +2971,11 @@ impl TypeChecker {
         self.return_type_stack.push(decl.return_type.kind.clone());
         self.observed_return_types.push(Vec::new());
         let error_checkpoint = self.errors.len();
-        if !matches!(decl.return_type.kind, TyKind::Unknown)
-            && let Some(expr) = &mut decl.body.expr
-        {
-            self.apply_expected_expr_type(expr, &decl.return_type.kind);
-        }
-        self.visit_block(&mut decl.body, &mut ());
+        let expected_return = (!matches!(decl.return_type.kind, TyKind::Unknown))
+            .then_some(decl.return_type.kind.clone());
+        self.typecheck_executable_block(&mut decl.body, expected_return, error_checkpoint);
         self.recheck_body_with_provisional_return(decl, error_checkpoint);
+        self.flush_local_inference_errors();
         self.check_function_body_return(decl);
 
         if matches!(decl.return_type.kind, TyKind::Unknown) {
@@ -2812,8 +3056,10 @@ impl HirPass for TypeChecker {
 // ── Visitor implementation ──────────────────────────────────────────────
 
 impl<'hir> Visitor<'hir> for TypeChecker {
-    fn visit_module(&mut self, module: &'hir mut hir::Module, ctx: &mut Self::Context) {
-        walk_module(self, module, ctx);
+    fn visit_module(&mut self, module: &'hir mut hir::Module, _ctx: &mut Self::Context) {
+        let error_checkpoint = self.errors.len();
+        self.typecheck_executable_block(&mut module.block, None, error_checkpoint);
+        self.flush_local_inference_errors();
     }
 
     fn visit_block(&mut self, block: &'hir mut hir::Block, ctx: &mut Self::Context) {
@@ -2824,6 +3070,8 @@ impl<'hir> Visitor<'hir> for TypeChecker {
     fn visit_stmt(&mut self, stmt: &'hir mut hir::Stmt, ctx: &mut Self::Context) {
         match &mut stmt.kind {
             hir::StmtKind::Let(pat, expr, ty) => {
+                self.seed_local_inference_binding_type(pat, ty);
+                self.seed_local_inference_literal_expr(pat, expr);
                 // Contextual inference for unannotated loop accumulators:
                 // when a `let accumulator$$` binding has no explicit type
                 // annotation, try to adopt the iterator's item type so that
@@ -2839,7 +3087,7 @@ impl<'hir> Visitor<'hir> for TypeChecker {
                     hir::PatKind::Identifier(_, ident) if ident.as_str() == "iterator$$"
                 );
 
-                if is_accumulator && matches!(ty.kind, TyKind::Unknown) {
+                if is_accumulator && matches!(ty.kind, TyKind::Unknown | TyKind::Var(_)) {
                     // Consume the pending iterator item type (set by the iterator$$
                     // stmt immediately before this one).  Only apply it when the
                     // item type is a numeric primitive AND the initial value is a
@@ -2872,12 +3120,23 @@ impl<'hir> Visitor<'hir> for TypeChecker {
                 self.record_iterator_binding_item_type(pat, expr);
 
                 let expr_ty_kind = expr.ty.kind.clone();
+                let is_synthetic_placeholder = matches!(
+                    &pat.kind,
+                    hir::PatKind::Identifier(_, ident)
+                        if ident.as_str().starts_with("$anf$")
+                            || ident.as_str() == "accumulator$$"
+                );
 
                 // If there is an explicit annotation, check compatibility.
-                self.check_binding_type(ty, &expr_ty_kind, stmt.span);
+                if !(is_synthetic_placeholder && matches!(ty.kind, TyKind::Primitive(PrimTy::Nil)))
+                {
+                    self.check_binding_type(ty, &expr_ty_kind, stmt.span);
+                }
 
                 // The binding's type is the annotation if present, else inferred.
-                let binding_ty = if matches!(ty.kind, TyKind::Unknown) {
+                let binding_ty = if matches!(ty.kind, TyKind::Unknown)
+                    || is_synthetic_placeholder && matches!(ty.kind, TyKind::Primitive(PrimTy::Nil))
+                {
                     expr_ty_kind
                 } else {
                     ty.kind.clone()
@@ -2887,6 +3146,8 @@ impl<'hir> Visitor<'hir> for TypeChecker {
                 pat.ty.kind = binding_ty;
             }
             hir::StmtKind::Const(_, pat, expr, ty) => {
+                self.seed_local_inference_binding_type(pat, ty);
+                self.seed_local_inference_literal_expr(pat, expr);
                 if !matches!(ty.kind, TyKind::Unknown) {
                     self.apply_expected_expr_type(expr, &ty.kind);
                 }
@@ -2969,6 +3230,11 @@ impl<'hir> Visitor<'hir> for TypeChecker {
                             expr.ty.kind,
                             TyKind::Primitive(prim) if prim.is_numeric()
                         ) =>
+                    {
+                        expr.ty.kind.clone()
+                    }
+                    Literal::Integer(_) | Literal::UnsignedInteger(_) | Literal::Float(_)
+                        if matches!(expr.ty.kind, TyKind::Var(_)) =>
                     {
                         expr.ty.kind.clone()
                     }

--- a/crates/tlang_typeck/src/type_checker.rs
+++ b/crates/tlang_typeck/src/type_checker.rs
@@ -101,14 +101,18 @@ impl TypeChecker {
         let Some(hir_id) = Self::local_binding_hir_id(pat) else {
             return;
         };
-        let Some(seed_ty) = self
+        // Guard: if there is no active seed for this binding, do nothing.
+        // The annotation field must stay Unknown when the user wrote no
+        // explicit type so that inlay hints can detect unannotated bindings.
+        // The seed type is propagated to the binding via
+        // `seed_local_inference_literal_expr` (for literal initialisers) and
+        // through the `expr_ty_kind` path in `binding_ty` computation.
+        let Some(_seed_ty) = self
             .current_local_inference_scope()
             .and_then(|scope| scope.seed_type_for_binding(hir_id))
         else {
             return;
         };
-
-        ty.kind = seed_ty;
     }
 
     fn seed_local_inference_literal_expr(&self, pat: &hir::Pat, expr: &mut hir::Expr) {
@@ -166,17 +170,17 @@ impl TypeChecker {
     fn typecheck_executable_block(
         &mut self,
         block: &mut hir::Block,
-        expected_return: Option<TyKind>,
+        expected_return: Option<&TyKind>,
         error_checkpoint: usize,
     ) {
         let scope = LocalInferenceScope::collect(block, &mut self.local_type_var_id_allocator);
         let has_candidates = !scope.is_empty();
         self.local_inference_scopes.push(scope);
 
-        if let Some(expected_return) = expected_return.as_ref()
+        if let Some(ret_ty) = expected_return
             && let Some(expr) = &mut block.expr
         {
-            self.apply_expected_expr_type(expr, expected_return);
+            self.apply_expected_expr_type(expr, ret_ty);
         }
         self.visit_block(block, &mut ());
 
@@ -189,8 +193,7 @@ impl TypeChecker {
             return;
         }
 
-        let local_inference_error = if let Err(error) = scope.solve(block, expected_return.as_ref())
-        {
+        let local_inference_error = if let Err(error) = scope.solve(block, expected_return) {
             scope.fallback_to_defaults();
             Some(error)
         } else {
@@ -204,10 +207,10 @@ impl TypeChecker {
 
         Self::reset_block_expr_types(block);
         self.local_inference_scopes.push(scope);
-        if let Some(expected_return) = expected_return.as_ref()
+        if let Some(ret_ty) = expected_return
             && let Some(expr) = &mut block.expr
         {
-            self.apply_expected_expr_type(expr, expected_return);
+            self.apply_expected_expr_type(expr, ret_ty);
         }
         self.visit_block(block, &mut ());
         self.local_inference_scopes
@@ -2888,8 +2891,8 @@ impl TypeChecker {
         self.return_type_stack.push(decl.return_type.kind.clone());
         self.observed_return_types.push(Vec::new());
         let error_checkpoint = self.errors.len();
-        let expected_return = (!matches!(decl.return_type.kind, TyKind::Unknown))
-            .then_some(decl.return_type.kind.clone());
+        let expected_return =
+            (!matches!(decl.return_type.kind, TyKind::Unknown)).then_some(&decl.return_type.kind);
         self.typecheck_executable_block(&mut decl.body, expected_return, error_checkpoint);
         self.recheck_body_with_provisional_return(decl, error_checkpoint);
         self.flush_local_inference_errors();
@@ -2971,8 +2974,8 @@ impl TypeChecker {
         self.return_type_stack.push(decl.return_type.kind.clone());
         self.observed_return_types.push(Vec::new());
         let error_checkpoint = self.errors.len();
-        let expected_return = (!matches!(decl.return_type.kind, TyKind::Unknown))
-            .then_some(decl.return_type.kind.clone());
+        let expected_return =
+            (!matches!(decl.return_type.kind, TyKind::Unknown)).then_some(&decl.return_type.kind);
         self.typecheck_executable_block(&mut decl.body, expected_return, error_checkpoint);
         self.recheck_body_with_provisional_return(decl, error_checkpoint);
         self.flush_local_inference_errors();

--- a/crates/tlang_typeck/src/type_checker.rs
+++ b/crates/tlang_typeck/src/type_checker.rs
@@ -45,14 +45,6 @@ pub struct TypeChecker {
     dot_methods: HashMap<String, tlang_span::HirId>,
     /// Synthetic for-loop iterator bindings keyed by the lowered iterator local.
     iterator_item_types: HashMap<tlang_span::HirId, TyKind>,
-    /// The item type of the most recently visited for-loop iterator binding.
-    ///
-    /// Set by `record_iterator_binding_item_type` when processing a
-    /// `let iterator$$` statement.  Consumed once by the immediately following
-    /// `let accumulator$$` statement to enable contextual numeric literal
-    /// inference for unannotated loop accumulators (e.g. `with sum = 0`
-    /// infers `sum: isize` when the iterator yields `isize` items).
-    pending_accumulator_type: Option<TyKind>,
     /// Allocator for checker-local type variables used by two-phase local
     /// binding inference. Starts well above lowering/builtin ids to avoid
     /// collisions with generic type parameter vars.
@@ -339,7 +331,7 @@ impl TypeChecker {
     }
 
     fn record_iterator_binding_item_type(&mut self, pat: &hir::Pat, expr: &hir::Expr) {
-        let hir::PatKind::Identifier(hir_id, ident) = &pat.kind else {
+        let hir::PatKind::Identifier(hir_id, _) = &pat.kind else {
             return;
         };
         let hir::ExprKind::Call(call) = &expr.kind else {
@@ -352,12 +344,7 @@ impl TypeChecker {
             return;
         }
         if let Some(item_ty) = self.iterable_item_type(&call.arguments[0].ty.kind) {
-            self.iterator_item_types.insert(*hir_id, item_ty.clone());
-            if ident.as_str() == "iterator$$" {
-                // Store as pending so the next `let accumulator$$` binding can
-                // adopt this type when the accumulator has no outer annotation.
-                self.pending_accumulator_type = Some(item_ty);
-            }
+            self.iterator_item_types.insert(*hir_id, item_ty);
         }
     }
 
@@ -3075,46 +3062,6 @@ impl<'hir> Visitor<'hir> for TypeChecker {
             hir::StmtKind::Let(pat, expr, ty) => {
                 self.seed_local_inference_binding_type(pat, ty);
                 self.seed_local_inference_literal_expr(pat, expr);
-                // Contextual inference for unannotated loop accumulators:
-                // when a `let accumulator$$` binding has no explicit type
-                // annotation, try to adopt the iterator's item type so that
-                // bare numeric literals like `0` pick up the right numeric
-                // type without requiring an explicit cast (e.g. `with sum = 0`
-                // infers `sum: isize` when the iterator yields `isize` items).
-                let is_accumulator = matches!(
-                    &pat.kind,
-                    hir::PatKind::Identifier(_, ident) if ident.as_str() == "accumulator$$"
-                );
-                let is_iterator = matches!(
-                    &pat.kind,
-                    hir::PatKind::Identifier(_, ident) if ident.as_str() == "iterator$$"
-                );
-
-                if is_accumulator && matches!(ty.kind, TyKind::Unknown | TyKind::Var(_)) {
-                    // Consume the pending iterator item type (set by the iterator$$
-                    // stmt immediately before this one).  Only apply it when the
-                    // item type is a numeric primitive AND the initial value is a
-                    // bare integer or float literal (not a cast, call, etc.) so
-                    // that explicit initialiser types are always respected.
-                    if let Some(item_ty) = self.pending_accumulator_type.take()
-                        && matches!(&item_ty, TyKind::Primitive(prim) if prim.is_numeric())
-                        && matches!(
-                            &expr.kind,
-                            hir::ExprKind::Literal(lit)
-                                if matches!(lit.as_ref(),
-                                    Literal::Integer(_)
-                                    | Literal::UnsignedInteger(_)
-                                    | Literal::Float(_))
-                        )
-                    {
-                        ty.kind = item_ty;
-                    }
-                } else if !is_iterator {
-                    // Clear pending accumulator type for any stmt that is neither
-                    // the iterator$$ nor the accumulator$$, preventing leakage to
-                    // unrelated bindings.
-                    self.pending_accumulator_type = None;
-                }
 
                 if !matches!(ty.kind, TyKind::Unknown) {
                     self.apply_expected_expr_type(expr, &ty.kind);
@@ -3123,22 +3070,23 @@ impl<'hir> Visitor<'hir> for TypeChecker {
                 self.record_iterator_binding_item_type(pat, expr);
 
                 let expr_ty_kind = expr.ty.kind.clone();
-                let is_synthetic_placeholder = matches!(
+                // $anf$ temporaries are nil-initialized placeholders emitted by
+                // the ANF transform; skip the annotation type-check for them so
+                // that the nil init does not produce a spurious BindingTypeMismatch.
+                let is_anf_placeholder = matches!(
                     &pat.kind,
                     hir::PatKind::Identifier(_, ident)
                         if ident.as_str().starts_with("$anf$")
-                            || ident.as_str() == "accumulator$$"
                 );
 
                 // If there is an explicit annotation, check compatibility.
-                if !(is_synthetic_placeholder && matches!(ty.kind, TyKind::Primitive(PrimTy::Nil)))
-                {
+                if !(is_anf_placeholder && matches!(ty.kind, TyKind::Primitive(PrimTy::Nil))) {
                     self.check_binding_type(ty, &expr_ty_kind, stmt.span);
                 }
 
                 // The binding's type is the annotation if present, else inferred.
                 let binding_ty = if matches!(ty.kind, TyKind::Unknown)
-                    || is_synthetic_placeholder && matches!(ty.kind, TyKind::Primitive(PrimTy::Nil))
+                    || is_anf_placeholder && matches!(ty.kind, TyKind::Primitive(PrimTy::Nil))
                 {
                     expr_ty_kind
                 } else {

--- a/crates/tlang_typeck/tests/type_checker.rs
+++ b/crates/tlang_typeck/tests/type_checker.rs
@@ -2718,6 +2718,50 @@ fn loop_accumulator_unannotated_infers_type_from_iterator_item() {
 }
 
 #[test]
+fn manual_loop_local_numeric_binding_infers_from_iterator_usage() {
+    common::typecheck_ok(
+        r#"
+        enum Tree {
+            Empty,
+            Node { value: isize, left: Tree, right: Tree },
+        }
+
+        impl Iterable<isize> for Tree {
+            fn iter(self) {
+                Iterable::iter([])
+            }
+        }
+
+        let tree = Tree::Empty;
+        let iterator = Iterable::iter(tree);
+        let total = {
+            let sum = 0;
+            loop {
+                match Iterator::next(iterator) {
+                    Option::Some(x) => sum = sum + x,
+                    Option::None => break sum,
+                }
+            }
+        };
+        let _: isize = total;
+        "#,
+    );
+}
+
+#[test]
+fn local_numeric_binding_infers_from_later_assignment() {
+    common::typecheck_ok(
+        r#"
+        fn takes_isize(x: isize) -> isize { x }
+
+        let value = 0;
+        value = takes_isize(42);
+        let _: isize = value;
+        "#,
+    );
+}
+
+#[test]
 fn branch_literal_infers_from_function_return_type() {
     common::typecheck_ok(
         r#"

--- a/crates/tlang_typeck/tests/type_checker.rs
+++ b/crates/tlang_typeck/tests/type_checker.rs
@@ -2897,3 +2897,37 @@ fn binding_type_mismatch_i64_vs_string() {
     );
     assert!(!errs.is_empty(), "Expected error for String into i64");
 }
+
+#[test]
+fn return_stmt_constrains_local_numeric_binding() {
+    // A `return <expr>` statement should inform local inference the same way
+    // as a tail expression — the return type annotation constrains seeded locals.
+    common::typecheck_ok(
+        r#"
+        fn takes_isize(x: isize) -> isize { x }
+
+        fn make_isize() -> isize {
+            let acc = 0;
+            acc = takes_isize(42);
+            return acc;
+        }
+        "#,
+    );
+}
+
+#[test]
+fn mixed_numeric_arithmetic_no_spurious_conflict() {
+    // A seeded local used in arithmetic with both an i64 and an f64 operand
+    // should resolve to f64 (the widened type) without a spurious conflict.
+    common::typecheck_ok(
+        r#"
+        fn get_i64() -> i64 { 1 }
+        fn get_f64() -> f64 { 1.5 }
+
+        let x = 0;
+        let _a = x + get_i64();
+        let _b = x + get_f64();
+        let _: f64 = _b;
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

This replaces the narrow accumulator-only numeric literal inference path with a two-phase local inference flow in `tlang_typeck`.

The new flow:

1. Collects refineable local bindings in an executable body (`module.block`, function body, closure body).
2. Seeds those bindings with checker-local `TyKind::Var` placeholders instead of hardening bare numeric literals immediately.
3. Solves local constraints from later usage and re-runs the body with zonked concrete types.

That keeps the current `for`-loop accumulator behavior working, but also generalizes the same inference to manually written iterator loops and plain local assignments that only become typed after later uses.

## What changed

### New local inference layer

- Added `crates/tlang_typeck/src/local_inference.rs`.
- Introduced a local-inference scope that:
  - discovers refineable local identifier bindings initialized from bare numeric literals,
  - reuses `UnificationTable` for solving,
  - records solved binding types for a second check pass.

### `TypeChecker` integration

- Integrated the local solver into executable-body checking for:
  - module bodies,
  - function bodies,
  - closure bodies.
- Added a recheck path that resets expression types and recomputes them with solved local types.
- Kept existing top-down expected-type propagation in place, but made it cooperate with the new bottom-up local solving.

### Loop / iterator generalization

- Preserved existing lowered `for` accumulator inference behavior.
- Generalized iterator item tracking so manually written `let iterator = Iterable::iter(...)` loops can infer element types the same way as lowered `for` loops.
- Ensured mixed-numeric `for` accumulator cases still respect the annotated result type instead of over-constraining the accumulator from the iterator item type.

### Synthetic placeholder handling

- Preserved JS-optimizer placeholder behavior by continuing to treat synthetic `nil`-initialized placeholders (ANF temps and lowered accumulator placeholders) as inferred temporaries rather than user-authored typed bindings.
- This avoids regressing the JavaScript backend after the new recheck flow.

## Tests

Added regression coverage for the generalized cases in `crates/tlang_typeck/tests/type_checker.rs`:

- manual iterator loop local numeric inference,
- later-assignment local numeric refinement,
- existing `for` accumulator cases,
- mixed-numeric accumulator coercion.

Validated with:

- `cargo nextest run --profile=ci -p tlang_typeck`
- `make test`

## Why this shape

The previous approach depended on the synthetic lowered names `iterator$$` / `accumulator$$`. That was enough for the original `for`-loop case, but it did not scale to semantically equivalent hand-written loops or similar local-binding patterns.

This change keeps the implementation scoped to local executable bodies and refineable numeric bindings, but moves the design toward principled local solving instead of adding more special cases around lowered HIR names.
