### PR TITLE
fix(codegen): lower protocol generic method dispatch

### DIFF
--- a/crates/tlang_analysis/src/inlay_hints.rs
+++ b/crates/tlang_analysis/src/inlay_hints.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use tlang_ast::token::Literal;
 use tlang_hir as hir;
 use tlang_hir::{PrimTy, TyKind};
 use tlang_span::{HirId, LineColumn, Span, TypeVarId};
@@ -966,12 +967,20 @@ fn collect_fn_decl_definition_types(
             let params: Vec<String> = decl
                 .parameters
                 .iter()
-                .map(|param| {
+                .enumerate()
+                .map(|(index, param)| {
                     let param_ty = preferred_decl_hint_ty(
                         &param.type_annotation.kind,
                         type_table.get(&param.hir_id).map(|info| &info.ty.kind),
                     );
-                    format_ty_kind(param_ty, &type_var_names)
+                    if !param.has_type_annotation && matches!(param_ty, TyKind::Unknown) {
+                        infer_match_lowered_param_hint_ty(decl, type_table, index).map_or_else(
+                            || format_ty_kind(param_ty, &type_var_names),
+                            |inferred| format_ty_kind(&inferred, &type_var_names),
+                        )
+                    } else {
+                        format_ty_kind(param_ty, &type_var_names)
+                    }
                 })
                 .collect();
             let ret = preferred_decl_hint_ty(
@@ -1043,6 +1052,86 @@ fn collect_fn_decl_definition_types(
     }
 
     collect_block_definition_types(&decl.body, type_table, &type_var_names, out);
+}
+
+fn infer_match_lowered_param_hint_ty(
+    decl: &hir::FunctionDeclaration,
+    type_table: &TypeTable,
+    index: usize,
+) -> Option<TyKind> {
+    if !decl.is_match_lowered {
+        return None;
+    }
+
+    let Some(body_expr) = decl.body.expr.as_ref() else {
+        return None;
+    };
+    let hir::ExprKind::Match(_, arms, _) = &body_expr.kind else {
+        return None;
+    };
+
+    let arity = decl.parameters.len();
+    let mut inferred: Option<TyKind> = None;
+    let mut saw_constraining_arm = false;
+
+    for arm in arms {
+        let Some(column_pat) = match_lowered_param_pat(&arm.pat, index, arity) else {
+            return None;
+        };
+        let Some(candidate) = infer_match_lowered_pat_hint_ty(column_pat, type_table) else {
+            continue;
+        };
+        saw_constraining_arm = true;
+        if let Some(existing) = &inferred {
+            if *existing != candidate {
+                return None;
+            }
+        } else {
+            inferred = Some(candidate);
+        }
+    }
+
+    saw_constraining_arm.then_some(inferred).flatten()
+}
+
+fn match_lowered_param_pat(pat: &hir::Pat, index: usize, arity: usize) -> Option<&hir::Pat> {
+    if arity == 1 {
+        return Some(pat);
+    }
+
+    match &pat.kind {
+        hir::PatKind::List(items)
+            if items.len() == arity
+                && !items
+                    .iter()
+                    .any(|item| matches!(item.kind, hir::PatKind::Rest(_))) =>
+        {
+            items.get(index)
+        }
+        _ => None,
+    }
+}
+
+fn infer_match_lowered_pat_hint_ty(pat: &hir::Pat, type_table: &TypeTable) -> Option<TyKind> {
+    match &pat.kind {
+        hir::PatKind::Identifier(..) | hir::PatKind::Wildcard | hir::PatKind::Rest(_) => None,
+        hir::PatKind::Literal(lit) => Some(match lit.as_ref() {
+            Literal::Integer(_) | Literal::UnsignedInteger(_) => TyKind::Primitive(PrimTy::I64),
+            Literal::Float(_) => TyKind::Primitive(PrimTy::F64),
+            Literal::Boolean(_) => TyKind::Primitive(PrimTy::Bool),
+            Literal::String(_) => TyKind::Primitive(PrimTy::String),
+            Literal::Char(_) => TyKind::Primitive(PrimTy::Char),
+            Literal::None => TyKind::Primitive(PrimTy::Nil),
+        }),
+        hir::PatKind::List(_) => Some(TyKind::List(Box::new(hir::Ty::unknown()))),
+        hir::PatKind::Enum(path, _) => type_table.get(&path.res.hir_id()?).map(|info| match &info
+            .ty
+            .kind
+        {
+            TyKind::Fn(_, ret) => ret.kind.clone(),
+            kind => kind.clone(),
+        }),
+    }
 }
 
 fn check_pat_for_type(

--- a/crates/tlang_analysis/src/inlay_hints.rs
+++ b/crates/tlang_analysis/src/inlay_hints.rs
@@ -19,6 +19,7 @@ use tlang_hir as hir;
 use tlang_hir::{PrimTy, TyKind};
 use tlang_span::{HirId, LineColumn, Span, TypeVarId};
 use tlang_typeck::TypeTable;
+use tlang_typeck::match_lowered_param_pat;
 
 // Re-export from the dedicated typed_hir module so existing consumers
 // (e.g. `use crate::inlay_hints::TypedHir`) keep working.
@@ -1092,24 +1093,6 @@ fn infer_match_lowered_param_hint_ty(
     }
 
     saw_constraining_arm.then_some(inferred).flatten()
-}
-
-fn match_lowered_param_pat(pat: &hir::Pat, index: usize, arity: usize) -> Option<&hir::Pat> {
-    if arity == 1 {
-        return Some(pat);
-    }
-
-    match &pat.kind {
-        hir::PatKind::List(items)
-            if items.len() == arity
-                && !items
-                    .iter()
-                    .any(|item| matches!(item.kind, hir::PatKind::Rest(_))) =>
-        {
-            items.get(index)
-        }
-        _ => None,
-    }
 }
 
 fn infer_match_lowered_pat_hint_ty(pat: &hir::Pat, type_table: &TypeTable) -> Option<TyKind> {

--- a/crates/tlang_analysis/src/inlay_hints.rs
+++ b/crates/tlang_analysis/src/inlay_hints.rs
@@ -1064,9 +1064,7 @@ fn infer_match_lowered_param_hint_ty(
         return None;
     }
 
-    let Some(body_expr) = decl.body.expr.as_ref() else {
-        return None;
-    };
+    let body_expr = decl.body.expr.as_ref()?;
     let hir::ExprKind::Match(_, arms, _) = &body_expr.kind else {
         return None;
     };
@@ -1076,9 +1074,7 @@ fn infer_match_lowered_param_hint_ty(
     let mut saw_constraining_arm = false;
 
     for arm in arms {
-        let Some(column_pat) = match_lowered_param_pat(&arm.pat, index, arity) else {
-            return None;
-        };
+        let column_pat = match_lowered_param_pat(&arm.pat, index, arity)?;
         let Some(candidate) = infer_match_lowered_pat_hint_ty(column_pat, type_table) else {
             continue;
         };

--- a/crates/tlang_analysis/src/member_resolution.rs
+++ b/crates/tlang_analysis/src/member_resolution.rs
@@ -1068,7 +1068,7 @@ fn resolve_bound_protocol_method(
         // Enqueue transitively-reachable constraint protocols.
         for constraint_name in &protocol.constraints {
             if let Some(constraint_protocol) = type_table.get_protocol_info(constraint_name) {
-                pending.push((constraint_protocol, std::collections::HashMap::new()));
+                pending.push((constraint_protocol, type_bindings.clone()));
             }
         }
 
@@ -1147,7 +1147,7 @@ fn complete_bound_protocol_methods(
         // Enqueue transitively-reachable constraint protocols.
         for constraint_name in &protocol.constraints {
             if let Some(constraint_protocol) = type_table.get_protocol_info(constraint_name) {
-                pending.push((constraint_protocol, std::collections::HashMap::new()));
+                pending.push((constraint_protocol, type_bindings.clone()));
             }
         }
 

--- a/crates/tlang_analysis/src/member_resolution.rs
+++ b/crates/tlang_analysis/src/member_resolution.rs
@@ -737,22 +737,81 @@ fn find_lowered_protocol_dispatch_in_stmt<'a>(
     }
 }
 
+type LoweredProtocolDispatch<'a> = (&'a hir::Expr, &'a tlang_ast::node::Ident, TyKind);
+
+fn source_has_receiver_dot(source: &str, member_span: &Span) -> bool {
+    source.as_bytes()[..member_span.start as usize]
+        .iter()
+        .rev()
+        .copied()
+        .find(|byte| !matches!(*byte, b' ' | b'\t' | b'\n' | b'\r'))
+        == Some(b'.')
+}
+
+fn find_lowered_protocol_dispatch_in_exprs<'a, I>(
+    source: &str,
+    exprs: I,
+    offset: u32,
+) -> Option<LoweredProtocolDispatch<'a>>
+where
+    I: IntoIterator<Item = &'a hir::Expr>,
+{
+    exprs
+        .into_iter()
+        .find_map(|expr| find_lowered_protocol_dispatch_in_expr(source, expr, offset))
+}
+
+fn find_lowered_protocol_dispatch_in_match_arms<'a>(
+    source: &str,
+    arms: &'a [hir::MatchArm],
+    offset: u32,
+) -> Option<LoweredProtocolDispatch<'a>> {
+    for arm in arms {
+        if let Some(guard) = &arm.guard
+            && let Some(found) = find_lowered_protocol_dispatch_in_expr(source, guard, offset)
+        {
+            return Some(found);
+        }
+        if let Some(found) = find_lowered_protocol_dispatch_in_block(source, &arm.block, offset) {
+            return Some(found);
+        }
+    }
+
+    None
+}
+
+fn find_lowered_protocol_dispatch_in_else_clauses<'a>(
+    source: &str,
+    else_clauses: &'a [hir::ElseClause],
+    offset: u32,
+) -> Option<LoweredProtocolDispatch<'a>> {
+    for clause in else_clauses {
+        if let Some(condition) = &clause.condition
+            && let Some(found) = find_lowered_protocol_dispatch_in_expr(source, condition, offset)
+        {
+            return Some(found);
+        }
+        if let Some(found) =
+            find_lowered_protocol_dispatch_in_block(source, &clause.consequence, offset)
+        {
+            return Some(found);
+        }
+    }
+
+    None
+}
+
 fn find_lowered_protocol_dispatch_in_expr<'a>(
     source: &str,
     expr: &'a hir::Expr,
     offset: u32,
-) -> Option<(&'a hir::Expr, &'a tlang_ast::node::Ident, TyKind)> {
+) -> Option<LoweredProtocolDispatch<'a>> {
     if let hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) = &expr.kind
         && let hir::ExprKind::Path(path) = &call.callee.kind
         && let Some(member) = path.segments.last().map(|segment| &segment.ident)
         && path.segments.len() >= 2
         && span_contains_offset(&member.span, offset)
-        && source.as_bytes()[..member.span.start as usize]
-            .iter()
-            .rev()
-            .skip_while(|&&b| b == b' ' || b == b'\t' || b == b'\n' || b == b'\r')
-            .next()
-            == Some(&b'.')
+        && source_has_receiver_dot(source, &member.span)
         && let Some(receiver) = call.arguments.first()
     {
         return Some((receiver, member, receiver.ty.kind.clone()));
@@ -760,95 +819,45 @@ fn find_lowered_protocol_dispatch_in_expr<'a>(
 
     match &expr.kind {
         hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) => {
-            if let Some(found) =
-                find_lowered_protocol_dispatch_in_expr(source, &call.callee, offset)
-            {
-                return Some(found);
-            }
-            for arg in &call.arguments {
-                if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, arg, offset) {
-                    return Some(found);
-                }
-            }
+            find_lowered_protocol_dispatch_in_expr(source, &call.callee, offset).or_else(|| {
+                find_lowered_protocol_dispatch_in_exprs(source, call.arguments.iter(), offset)
+            })
         }
         hir::ExprKind::Block(block) | hir::ExprKind::Loop(block) => {
-            return find_lowered_protocol_dispatch_in_block(source, block, offset);
+            find_lowered_protocol_dispatch_in_block(source, block, offset)
         }
         hir::ExprKind::FieldAccess(base, _)
         | hir::ExprKind::Unary(_, base)
         | hir::ExprKind::Cast(base, _)
         | hir::ExprKind::TryCast(base, _)
         | hir::ExprKind::Implements(base, _) => {
-            return find_lowered_protocol_dispatch_in_expr(source, base, offset);
+            find_lowered_protocol_dispatch_in_expr(source, base, offset)
         }
         hir::ExprKind::Let(_, value) => {
-            return find_lowered_protocol_dispatch_in_expr(source, value, offset);
+            find_lowered_protocol_dispatch_in_expr(source, value, offset)
         }
         hir::ExprKind::IndexAccess(base, index) => {
-            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, base, offset) {
-                return Some(found);
-            }
-            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, index, offset) {
-                return Some(found);
-            }
+            find_lowered_protocol_dispatch_in_exprs(source, [base.as_ref(), index.as_ref()], offset)
         }
         hir::ExprKind::Binary(_, lhs, rhs) => {
-            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, lhs, offset) {
-                return Some(found);
-            }
-            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, rhs, offset) {
-                return Some(found);
-            }
+            find_lowered_protocol_dispatch_in_exprs(source, [lhs.as_ref(), rhs.as_ref()], offset)
         }
         hir::ExprKind::IfElse(condition, then_block, else_clauses) => {
-            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, condition, offset) {
-                return Some(found);
-            }
-            if let Some(found) = find_lowered_protocol_dispatch_in_block(source, then_block, offset)
-            {
-                return Some(found);
-            }
-            for clause in else_clauses {
-                if let Some(condition) = &clause.condition
-                    && let Some(found) =
-                        find_lowered_protocol_dispatch_in_expr(source, condition, offset)
-                {
-                    return Some(found);
-                }
-                if let Some(found) =
-                    find_lowered_protocol_dispatch_in_block(source, &clause.consequence, offset)
-                {
-                    return Some(found);
-                }
-            }
+            find_lowered_protocol_dispatch_in_expr(source, condition, offset)
+                .or_else(|| find_lowered_protocol_dispatch_in_block(source, then_block, offset))
+                .or_else(|| {
+                    find_lowered_protocol_dispatch_in_else_clauses(source, else_clauses, offset)
+                })
         }
         hir::ExprKind::FunctionExpression(decl) => {
-            return find_lowered_protocol_dispatch_in_block(source, &decl.body, offset);
+            find_lowered_protocol_dispatch_in_block(source, &decl.body, offset)
         }
         hir::ExprKind::Match(scrutinee, arms, _) => {
-            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, scrutinee, offset) {
-                return Some(found);
-            }
-            for arm in arms {
-                if let Some(guard) = &arm.guard
-                    && let Some(found) =
-                        find_lowered_protocol_dispatch_in_expr(source, guard, offset)
-                {
-                    return Some(found);
-                }
-                if let Some(found) =
-                    find_lowered_protocol_dispatch_in_block(source, &arm.block, offset)
-                {
-                    return Some(found);
-                }
-            }
+            find_lowered_protocol_dispatch_in_expr(source, scrutinee, offset)
+                .or_else(|| find_lowered_protocol_dispatch_in_match_arms(source, arms, offset))
         }
         hir::ExprKind::List(items) => {
-            for item in items {
-                if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, item, offset) {
-                    return Some(found);
-                }
-            }
+            find_lowered_protocol_dispatch_in_exprs(source, items.iter(), offset)
         }
         hir::ExprKind::Dict(entries) => {
             for (key, value) in entries {
@@ -859,39 +868,25 @@ fn find_lowered_protocol_dispatch_in_expr<'a>(
                     return Some(found);
                 }
             }
+
+            None
         }
         hir::ExprKind::TaggedString { tag, exprs, .. } => {
-            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, tag, offset) {
-                return Some(found);
-            }
-            for item in exprs {
-                if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, item, offset) {
-                    return Some(found);
-                }
-            }
+            find_lowered_protocol_dispatch_in_expr(source, tag, offset)
+                .or_else(|| find_lowered_protocol_dispatch_in_exprs(source, exprs.iter(), offset))
         }
         hir::ExprKind::Range(range) => {
-            if let Some(found) =
-                find_lowered_protocol_dispatch_in_expr(source, &range.start, offset)
-            {
-                return Some(found);
-            }
-            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, &range.end, offset)
-            {
-                return Some(found);
-            }
+            find_lowered_protocol_dispatch_in_exprs(source, [&range.start, &range.end], offset)
         }
         hir::ExprKind::Literal(_)
         | hir::ExprKind::Path(_)
         | hir::ExprKind::Continue
         | hir::ExprKind::Break(None)
-        | hir::ExprKind::Wildcard => {}
+        | hir::ExprKind::Wildcard => None,
         hir::ExprKind::Break(Some(value)) => {
-            return find_lowered_protocol_dispatch_in_expr(source, value, offset);
+            find_lowered_protocol_dispatch_in_expr(source, value, offset)
         }
     }
-
-    None
 }
 
 // ── Receiver type resolution for dot-completion ────────────────────────

--- a/crates/tlang_analysis/src/member_resolution.rs
+++ b/crates/tlang_analysis/src/member_resolution.rs
@@ -742,17 +742,20 @@ fn find_lowered_protocol_dispatch_in_expr<'a>(
     expr: &'a hir::Expr,
     offset: u32,
 ) -> Option<(&'a hir::Expr, &'a tlang_ast::node::Ident, TyKind)> {
-    if let hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) = &expr.kind {
-        if let hir::ExprKind::Path(path) = &call.callee.kind
-            && let Some(member) = path.segments.last().map(|segment| &segment.ident)
-            && path.segments.len() >= 2
-            && span_contains_offset(&member.span, offset)
-            && member.span.start > 0
-            && source.as_bytes().get(member.span.start as usize - 1) == Some(&b'.')
-            && let Some(receiver) = call.arguments.first()
-        {
-            return Some((receiver, member, receiver.ty.kind.clone()));
-        }
+    if let hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) = &expr.kind
+        && let hir::ExprKind::Path(path) = &call.callee.kind
+        && let Some(member) = path.segments.last().map(|segment| &segment.ident)
+        && path.segments.len() >= 2
+        && span_contains_offset(&member.span, offset)
+        && source.as_bytes()[..member.span.start as usize]
+            .iter()
+            .rev()
+            .skip_while(|&&b| b == b' ' || b == b'\t' || b == b'\n' || b == b'\r')
+            .next()
+            == Some(&b'.')
+        && let Some(receiver) = call.arguments.first()
+    {
+        return Some((receiver, member, receiver.ty.kind.clone()));
     }
 
     match &expr.kind {
@@ -1038,20 +1041,45 @@ fn resolve_bound_protocol_method(
     };
 
     let bounds = type_table.get_type_param_bounds(*type_var_id)?;
+
+    // Build a work-list that includes all transitively reachable constraint
+    // protocols so that, e.g., a `T: Ord` bound also exposes `Eq`/`PartialEq`
+    // methods that `Ord` inherits.
+    let mut pending: Vec<(
+        &tlang_typeck::ProtocolInfo,
+        std::collections::HashMap<tlang_span::TypeVarId, TyKind>,
+    )> = Vec::new();
     for bound in bounds {
-        let Some((protocol, type_args)) = type_table.resolve_protocol_bound(bound) else {
+        if let Some((protocol, type_args)) = type_table.resolve_protocol_bound(bound) {
+            let mut bindings = std::collections::HashMap::new();
+            for (proto_type_param, type_arg) in protocol.type_param_var_ids.iter().zip(type_args) {
+                bindings.insert(*proto_type_param, type_arg.kind.clone());
+            }
+            pending.push((protocol, bindings));
+        }
+    }
+
+    let mut visited_protocols = std::collections::HashSet::new();
+    while let Some((protocol, type_bindings)) = pending.pop() {
+        if !visited_protocols.insert(protocol.hir_id) {
             continue;
-        };
+        }
+
+        // Enqueue transitively-reachable constraint protocols.
+        for constraint_name in &protocol.constraints {
+            if let Some(constraint_protocol) = type_table.get_protocol_info(constraint_name) {
+                pending.push((constraint_protocol, std::collections::HashMap::new()));
+            }
+        }
+
         let protocol_name = protocol.name.to_string();
-        let method = protocol
+        let Some(method) = protocol
             .methods
             .iter()
-            .find(|candidate| candidate.name.as_str() == method_name)?;
-
-        let mut type_bindings = std::collections::HashMap::new();
-        for (proto_type_param, type_arg) in protocol.type_param_var_ids.iter().zip(type_args) {
-            type_bindings.insert(*proto_type_param, type_arg.kind.clone());
-        }
+            .find(|candidate| candidate.name.as_str() == method_name)
+        else {
+            continue;
+        };
 
         let params: Vec<String> = method
             .param_tys
@@ -1090,19 +1118,40 @@ fn complete_bound_protocol_methods(
         return vec![];
     };
 
+    // Build a work-list seeded with all direct bounds, then expand into
+    // transitively-reachable constraint protocols so completions include
+    // inherited methods (e.g. `Eq`/`PartialEq` for a `T: Ord` bound).
+    let mut pending: Vec<(
+        &tlang_typeck::ProtocolInfo,
+        std::collections::HashMap<tlang_span::TypeVarId, TyKind>,
+    )> = Vec::new();
+    for bound in bounds {
+        if let Some((protocol, type_args)) = type_table.resolve_protocol_bound(bound) {
+            let mut bindings = std::collections::HashMap::new();
+            for (proto_type_param, type_arg) in protocol.type_param_var_ids.iter().zip(type_args) {
+                bindings.insert(*proto_type_param, type_arg.kind.clone());
+            }
+            pending.push((protocol, bindings));
+        }
+    }
+
+    let mut visited_protocols = std::collections::HashSet::new();
     let mut seen = std::collections::HashSet::new();
     let mut candidates = Vec::new();
 
-    for bound in bounds {
-        let Some((protocol, type_args)) = type_table.resolve_protocol_bound(bound) else {
+    while let Some((protocol, type_bindings)) = pending.pop() {
+        if !visited_protocols.insert(protocol.hir_id) {
             continue;
-        };
-        let protocol_name = protocol.name.to_string();
-
-        let mut type_bindings = std::collections::HashMap::new();
-        for (proto_type_param, type_arg) in protocol.type_param_var_ids.iter().zip(type_args) {
-            type_bindings.insert(*proto_type_param, type_arg.kind.clone());
         }
+
+        // Enqueue transitively-reachable constraint protocols.
+        for constraint_name in &protocol.constraints {
+            if let Some(constraint_protocol) = type_table.get_protocol_info(constraint_name) {
+                pending.push((constraint_protocol, std::collections::HashMap::new()));
+            }
+        }
+
+        let protocol_name = protocol.name.to_string();
 
         for method in &protocol.methods {
             let name = method.name.to_string();

--- a/crates/tlang_analysis/src/member_resolution.rs
+++ b/crates/tlang_analysis/src/member_resolution.rs
@@ -83,13 +83,17 @@ pub fn resolve_member_at_position(
     utf16_col: u32,
 ) -> Option<ResolvedMember> {
     let offset = utf16_line_column_to_byte_offset(source, line, utf16_col);
-    let (_base, ident, base_ty) = find_field_access_at_offset(&typed_hir.module.block, offset)?;
-
-    let type_name = builtin_methods::type_name_from_kind(&base_ty)?;
+    let (_base, ident, base_ty) = find_field_access_at_offset(&typed_hir.module.block, offset)
+        .or_else(|| {
+            find_lowered_protocol_dispatch_at_offset(source, &typed_hir.module.block, offset)
+        })?;
     let member_name = ident.as_str();
+    let type_name = builtin_methods::type_name_from_kind(&base_ty);
 
     // 1. Try builtin methods first.
-    if let Some(sig_ty) = builtin_methods::lookup(type_name, member_name) {
+    if let Some(type_name) = type_name.as_ref()
+        && let Some(sig_ty) = builtin_methods::lookup(type_name, member_name)
+    {
         let sig_ty = builtin_methods::substitute_receiver_type_vars(&base_ty, &sig_ty);
         let return_ty = extract_return_ty(&sig_ty);
         let signature = signature_from_builtin(type_name, member_name, &sig_ty);
@@ -104,8 +108,28 @@ pub fn resolve_member_at_position(
         });
     }
 
-    // 2. Try user-defined methods from protocol impls.
-    if let Some(info) = resolve_protocol_method(&typed_hir.type_table, type_name, member_name) {
+    // 2. Try methods from protocol bounds on a generic receiver.
+    if let Some(info) = resolve_bound_protocol_method(
+        &typed_hir.module.block,
+        &typed_hir.type_table,
+        &base_ty,
+        member_name,
+    ) {
+        return Some(ResolvedMember {
+            name: member_name.to_string(),
+            receiver_ty: base_ty,
+            kind: MemberKind::Method,
+            signature: Some(info.0),
+            return_ty: info.1,
+            def_span: info.2,
+            builtin: false,
+        });
+    }
+
+    // 3. Try user-defined methods from protocol impls.
+    if let Some(type_name) = type_name.as_ref()
+        && let Some(info) = resolve_protocol_method(&typed_hir.type_table, type_name, member_name)
+    {
         return Some(ResolvedMember {
             name: member_name.to_string(),
             receiver_ty: base_ty,
@@ -117,8 +141,10 @@ pub fn resolve_member_at_position(
         });
     }
 
-    // 3. Try builtin fields.
-    if let Some(field_ty) = builtin_fields::lookup(type_name, member_name) {
+    // 4. Try builtin fields.
+    if let Some(type_name) = type_name.as_ref()
+        && let Some(field_ty) = builtin_fields::lookup(type_name, member_name)
+    {
         return Some(ResolvedMember {
             name: member_name.to_string(),
             receiver_ty: base_ty,
@@ -130,8 +156,10 @@ pub fn resolve_member_at_position(
         });
     }
 
-    // 4. Try user-defined methods/fields from the HIR (struct methods, etc.).
-    if let Some(info) = resolve_hir_member(&typed_hir.module.block, type_name, member_name) {
+    // 5. Try user-defined methods/fields from the HIR (struct methods, etc.).
+    if let Some(type_name) = type_name.as_ref()
+        && let Some(info) = resolve_hir_member(&typed_hir.module.block, type_name, member_name)
+    {
         return Some(ResolvedMember {
             name: member_name.to_string(),
             receiver_ty: base_ty,
@@ -158,13 +186,13 @@ pub fn complete_members_at_position(
     line: u32,
     utf16_col: u32,
 ) -> Vec<MemberCandidate> {
-    let type_name = receiver_type_before_dot(source, typed_hir, line, utf16_col);
-    let type_name = match type_name {
+    let receiver_ty = receiver_type_before_dot(source, typed_hir, line, utf16_col);
+    let receiver_ty = match receiver_ty {
         Some(t) => t,
         None => return vec![],
     };
 
-    complete_members_for_type(typed_hir, symbol_index, &type_name)
+    complete_members_for_ty(typed_hir, symbol_index, &receiver_ty)
 }
 
 /// List all member candidates for a given type name.
@@ -172,6 +200,37 @@ pub fn complete_members_at_position(
 /// This is a lower-level helper that can be called when the type name is
 /// already known (e.g. from `type_at_definition`).
 pub fn complete_members_for_type(
+    typed_hir: &TypedHir,
+    symbol_index: Option<&SymbolIndex>,
+    type_name: &str,
+) -> Vec<MemberCandidate> {
+    complete_members_for_concrete_type(typed_hir, symbol_index, type_name)
+}
+
+fn complete_members_for_ty(
+    typed_hir: &TypedHir,
+    symbol_index: Option<&SymbolIndex>,
+    ty: &TyKind,
+) -> Vec<MemberCandidate> {
+    if let TyKind::Var(type_var_id) = ty {
+        let candidates = complete_bound_protocol_methods(
+            &typed_hir.module.block,
+            &typed_hir.type_table,
+            *type_var_id,
+        );
+        if !candidates.is_empty() {
+            return candidates;
+        }
+    }
+
+    let Some(type_name) = type_name_for_ty(ty) else {
+        return vec![];
+    };
+
+    complete_members_for_concrete_type(typed_hir, symbol_index, &type_name)
+}
+
+fn complete_members_for_concrete_type(
     typed_hir: &TypedHir,
     symbol_index: Option<&SymbolIndex>,
     type_name: &str,
@@ -445,6 +504,14 @@ fn find_field_access_at_offset(
     find_field_access_in_block(block, offset)
 }
 
+fn find_lowered_protocol_dispatch_at_offset<'a>(
+    source: &str,
+    block: &'a hir::Block,
+    offset: u32,
+) -> Option<(&'a hir::Expr, &'a tlang_ast::node::Ident, TyKind)> {
+    find_lowered_protocol_dispatch_in_block(source, block, offset)
+}
+
 fn find_field_access_in_block(
     block: &hir::Block,
     offset: u32,
@@ -628,6 +695,202 @@ fn find_field_access_in_expr(
     None
 }
 
+fn find_lowered_protocol_dispatch_in_block<'a>(
+    source: &str,
+    block: &'a hir::Block,
+    offset: u32,
+) -> Option<(&'a hir::Expr, &'a tlang_ast::node::Ident, TyKind)> {
+    for stmt in &block.stmts {
+        if let Some(found) = find_lowered_protocol_dispatch_in_stmt(source, stmt, offset) {
+            return Some(found);
+        }
+    }
+    block
+        .expr
+        .as_ref()
+        .and_then(|expr| find_lowered_protocol_dispatch_in_expr(source, expr, offset))
+}
+
+fn find_lowered_protocol_dispatch_in_stmt<'a>(
+    source: &str,
+    stmt: &'a hir::Stmt,
+    offset: u32,
+) -> Option<(&'a hir::Expr, &'a tlang_ast::node::Ident, TyKind)> {
+    match &stmt.kind {
+        hir::StmtKind::Expr(expr) | hir::StmtKind::Return(Some(expr)) => {
+            find_lowered_protocol_dispatch_in_expr(source, expr, offset)
+        }
+        hir::StmtKind::Let(_, init, _) | hir::StmtKind::Const(_, _, init, _) => {
+            find_lowered_protocol_dispatch_in_expr(source, init, offset)
+        }
+        hir::StmtKind::FunctionDeclaration(decl) => {
+            find_lowered_protocol_dispatch_in_block(source, &decl.body, offset)
+        }
+        hir::StmtKind::ImplBlock(impl_block) => impl_block.methods.iter().find_map(|method| {
+            find_lowered_protocol_dispatch_in_block(source, &method.body, offset)
+        }),
+        hir::StmtKind::DynFunctionDeclaration(_)
+        | hir::StmtKind::Return(None)
+        | hir::StmtKind::StructDeclaration(_)
+        | hir::StmtKind::EnumDeclaration(_)
+        | hir::StmtKind::ProtocolDeclaration(_) => None,
+    }
+}
+
+fn find_lowered_protocol_dispatch_in_expr<'a>(
+    source: &str,
+    expr: &'a hir::Expr,
+    offset: u32,
+) -> Option<(&'a hir::Expr, &'a tlang_ast::node::Ident, TyKind)> {
+    if let hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) = &expr.kind {
+        if let hir::ExprKind::Path(path) = &call.callee.kind
+            && let Some(member) = path.segments.last().map(|segment| &segment.ident)
+            && path.segments.len() >= 2
+            && span_contains_offset(&member.span, offset)
+            && member.span.start > 0
+            && source.as_bytes().get(member.span.start as usize - 1) == Some(&b'.')
+            && let Some(receiver) = call.arguments.first()
+        {
+            return Some((receiver, member, receiver.ty.kind.clone()));
+        }
+    }
+
+    match &expr.kind {
+        hir::ExprKind::Call(call) | hir::ExprKind::TailCall(call) => {
+            if let Some(found) =
+                find_lowered_protocol_dispatch_in_expr(source, &call.callee, offset)
+            {
+                return Some(found);
+            }
+            for arg in &call.arguments {
+                if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, arg, offset) {
+                    return Some(found);
+                }
+            }
+        }
+        hir::ExprKind::Block(block) | hir::ExprKind::Loop(block) => {
+            return find_lowered_protocol_dispatch_in_block(source, block, offset);
+        }
+        hir::ExprKind::FieldAccess(base, _)
+        | hir::ExprKind::Unary(_, base)
+        | hir::ExprKind::Cast(base, _)
+        | hir::ExprKind::TryCast(base, _)
+        | hir::ExprKind::Implements(base, _) => {
+            return find_lowered_protocol_dispatch_in_expr(source, base, offset);
+        }
+        hir::ExprKind::Let(_, value) => {
+            return find_lowered_protocol_dispatch_in_expr(source, value, offset);
+        }
+        hir::ExprKind::IndexAccess(base, index) => {
+            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, base, offset) {
+                return Some(found);
+            }
+            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, index, offset) {
+                return Some(found);
+            }
+        }
+        hir::ExprKind::Binary(_, lhs, rhs) => {
+            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, lhs, offset) {
+                return Some(found);
+            }
+            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, rhs, offset) {
+                return Some(found);
+            }
+        }
+        hir::ExprKind::IfElse(condition, then_block, else_clauses) => {
+            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, condition, offset) {
+                return Some(found);
+            }
+            if let Some(found) = find_lowered_protocol_dispatch_in_block(source, then_block, offset)
+            {
+                return Some(found);
+            }
+            for clause in else_clauses {
+                if let Some(condition) = &clause.condition
+                    && let Some(found) =
+                        find_lowered_protocol_dispatch_in_expr(source, condition, offset)
+                {
+                    return Some(found);
+                }
+                if let Some(found) =
+                    find_lowered_protocol_dispatch_in_block(source, &clause.consequence, offset)
+                {
+                    return Some(found);
+                }
+            }
+        }
+        hir::ExprKind::FunctionExpression(decl) => {
+            return find_lowered_protocol_dispatch_in_block(source, &decl.body, offset);
+        }
+        hir::ExprKind::Match(scrutinee, arms, _) => {
+            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, scrutinee, offset) {
+                return Some(found);
+            }
+            for arm in arms {
+                if let Some(guard) = &arm.guard
+                    && let Some(found) =
+                        find_lowered_protocol_dispatch_in_expr(source, guard, offset)
+                {
+                    return Some(found);
+                }
+                if let Some(found) =
+                    find_lowered_protocol_dispatch_in_block(source, &arm.block, offset)
+                {
+                    return Some(found);
+                }
+            }
+        }
+        hir::ExprKind::List(items) => {
+            for item in items {
+                if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, item, offset) {
+                    return Some(found);
+                }
+            }
+        }
+        hir::ExprKind::Dict(entries) => {
+            for (key, value) in entries {
+                if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, key, offset) {
+                    return Some(found);
+                }
+                if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, value, offset) {
+                    return Some(found);
+                }
+            }
+        }
+        hir::ExprKind::TaggedString { tag, exprs, .. } => {
+            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, tag, offset) {
+                return Some(found);
+            }
+            for item in exprs {
+                if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, item, offset) {
+                    return Some(found);
+                }
+            }
+        }
+        hir::ExprKind::Range(range) => {
+            if let Some(found) =
+                find_lowered_protocol_dispatch_in_expr(source, &range.start, offset)
+            {
+                return Some(found);
+            }
+            if let Some(found) = find_lowered_protocol_dispatch_in_expr(source, &range.end, offset)
+            {
+                return Some(found);
+            }
+        }
+        hir::ExprKind::Literal(_)
+        | hir::ExprKind::Path(_)
+        | hir::ExprKind::Continue
+        | hir::ExprKind::Break(None)
+        | hir::ExprKind::Wildcard => {}
+        hir::ExprKind::Break(Some(value)) => {
+            return find_lowered_protocol_dispatch_in_expr(source, value, offset);
+        }
+    }
+
+    None
+}
+
 // ── Receiver type resolution for dot-completion ────────────────────────
 
 /// Determine the receiver type for dot-completion at a position.
@@ -640,7 +903,7 @@ fn receiver_type_before_dot(
     typed_hir: &TypedHir,
     line: u32,
     utf16_col: u32,
-) -> Option<String> {
+) -> Option<TyKind> {
     // The cursor is right after the dot — the dot is at col-1 and the
     // receiver ends before that.  We scan for the receiver in the typed
     // HIR by finding the expression at the dot position.
@@ -660,10 +923,10 @@ fn receiver_type_before_dot(
     if let Some(expr) = find_hir_expr_at_position(&typed_hir.module.block, dot_offset) {
         // If we landed on a FieldAccess, use the base type.
         if let hir::ExprKind::FieldAccess(base, _) = &expr.kind {
-            return type_name_for_ty(&base.ty.kind);
+            return Some(base.ty.kind.clone());
         }
         // Otherwise the expression itself might be the receiver.
-        return type_name_for_ty(&expr.ty.kind);
+        return Some(expr.ty.kind.clone());
     }
 
     None
@@ -762,6 +1025,206 @@ fn resolve_protocol_method(
     };
 
     Some((signature, Some(method.return_ty.kind.clone())))
+}
+
+fn resolve_bound_protocol_method(
+    block: &hir::Block,
+    type_table: &tlang_typeck::TypeTable,
+    receiver_ty: &TyKind,
+    method_name: &str,
+) -> Option<(SignatureInformation, Option<TyKind>, Option<Span>)> {
+    let TyKind::Var(type_var_id) = receiver_ty else {
+        return None;
+    };
+
+    let bounds = type_table.get_type_param_bounds(*type_var_id)?;
+    for bound in bounds {
+        let Some((protocol, type_args)) = type_table.resolve_protocol_bound(bound) else {
+            continue;
+        };
+        let protocol_name = protocol.name.to_string();
+        let method = protocol
+            .methods
+            .iter()
+            .find(|candidate| candidate.name.as_str() == method_name)?;
+
+        let mut type_bindings = std::collections::HashMap::new();
+        for (proto_type_param, type_arg) in protocol.type_param_var_ids.iter().zip(type_args) {
+            type_bindings.insert(*proto_type_param, type_arg.kind.clone());
+        }
+
+        let params: Vec<String> = method
+            .param_tys
+            .iter()
+            .skip(1)
+            .map(|ty| substitute_type_vars(&ty.kind, &type_bindings).to_string())
+            .collect();
+        let return_ty = substitute_type_vars(&method.return_ty.kind, &type_bindings);
+        let signature = SignatureInformation {
+            label: format!(
+                "{protocol_name}.{method_name}({}) -> {return_ty}",
+                params.join(", ")
+            ),
+            parameters: params
+                .into_iter()
+                .map(|label| ParameterInformation { label })
+                .collect(),
+        };
+
+        return Some((
+            signature,
+            Some(return_ty),
+            find_protocol_method_span(block, protocol.hir_id, &protocol_name, method_name),
+        ));
+    }
+
+    None
+}
+
+fn complete_bound_protocol_methods(
+    block: &hir::Block,
+    type_table: &tlang_typeck::TypeTable,
+    type_var_id: tlang_span::TypeVarId,
+) -> Vec<MemberCandidate> {
+    let Some(bounds) = type_table.get_type_param_bounds(type_var_id) else {
+        return vec![];
+    };
+
+    let mut seen = std::collections::HashSet::new();
+    let mut candidates = Vec::new();
+
+    for bound in bounds {
+        let Some((protocol, type_args)) = type_table.resolve_protocol_bound(bound) else {
+            continue;
+        };
+        let protocol_name = protocol.name.to_string();
+
+        let mut type_bindings = std::collections::HashMap::new();
+        for (proto_type_param, type_arg) in protocol.type_param_var_ids.iter().zip(type_args) {
+            type_bindings.insert(*proto_type_param, type_arg.kind.clone());
+        }
+
+        for method in &protocol.methods {
+            let name = method.name.to_string();
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+
+            let params: Vec<String> = method
+                .param_tys
+                .iter()
+                .skip(1)
+                .map(|ty| substitute_type_vars(&ty.kind, &type_bindings).to_string())
+                .collect();
+            let return_ty = substitute_type_vars(&method.return_ty.kind, &type_bindings);
+            let signature = SignatureInformation {
+                label: format!(
+                    "{protocol_name}.{name}({}) -> {return_ty}",
+                    params.join(", ")
+                ),
+                parameters: params
+                    .into_iter()
+                    .map(|label| ParameterInformation { label })
+                    .collect(),
+            };
+
+            candidates.push(MemberCandidate {
+                name,
+                kind: MemberKind::Method,
+                signature: Some(signature),
+                return_ty: Some(return_ty),
+                def_span: find_protocol_method_span(
+                    block,
+                    protocol.hir_id,
+                    &protocol_name,
+                    method.name.as_str(),
+                ),
+                builtin: false,
+            });
+        }
+    }
+
+    candidates
+}
+
+fn find_protocol_method_span(
+    block: &hir::Block,
+    protocol_hir_id: Option<tlang_span::HirId>,
+    protocol_name: &str,
+    method_name: &str,
+) -> Option<Span> {
+    block.stmts.iter().find_map(|stmt| match &stmt.kind {
+        hir::StmtKind::ProtocolDeclaration(decl)
+            if protocol_hir_id.is_some_and(|hir_id| decl.hir_id == hir_id)
+                || decl.name.as_str() == protocol_name =>
+        {
+            decl.methods
+                .iter()
+                .find(|method| method.name.as_str() == method_name)
+                .map(|method| method.name.span)
+        }
+        _ => None,
+    })
+}
+
+fn substitute_type_vars(
+    ty: &TyKind,
+    bindings: &std::collections::HashMap<tlang_span::TypeVarId, TyKind>,
+) -> TyKind {
+    match ty {
+        TyKind::Var(id) => bindings.get(id).cloned().unwrap_or_else(|| ty.clone()),
+        TyKind::Fn(params, ret) => TyKind::Fn(
+            params
+                .iter()
+                .map(|param| tlang_hir::Ty {
+                    kind: substitute_type_vars(&param.kind, bindings),
+                    ..param.clone()
+                })
+                .collect(),
+            Box::new(tlang_hir::Ty {
+                kind: substitute_type_vars(&ret.kind, bindings),
+                ..ret.as_ref().clone()
+            }),
+        ),
+        TyKind::List(inner) => TyKind::List(Box::new(tlang_hir::Ty {
+            kind: substitute_type_vars(&inner.kind, bindings),
+            ..inner.as_ref().clone()
+        })),
+        TyKind::Slice(inner) => TyKind::Slice(Box::new(tlang_hir::Ty {
+            kind: substitute_type_vars(&inner.kind, bindings),
+            ..inner.as_ref().clone()
+        })),
+        TyKind::Dict(key, value) => TyKind::Dict(
+            Box::new(tlang_hir::Ty {
+                kind: substitute_type_vars(&key.kind, bindings),
+                ..key.as_ref().clone()
+            }),
+            Box::new(tlang_hir::Ty {
+                kind: substitute_type_vars(&value.kind, bindings),
+                ..value.as_ref().clone()
+            }),
+        ),
+        TyKind::Path(path, type_args) => TyKind::Path(
+            path.clone(),
+            type_args
+                .iter()
+                .map(|type_arg| tlang_hir::Ty {
+                    kind: substitute_type_vars(&type_arg.kind, bindings),
+                    ..type_arg.clone()
+                })
+                .collect(),
+        ),
+        TyKind::Union(types) => TyKind::Union(
+            types
+                .iter()
+                .map(|ty| tlang_hir::Ty {
+                    kind: substitute_type_vars(&ty.kind, bindings),
+                    ..ty.clone()
+                })
+                .collect(),
+        ),
+        _ => ty.clone(),
+    }
 }
 
 /// Resolve a member from user-defined declarations in the HIR.
@@ -928,6 +1391,28 @@ mod tests {
                 result.all_diagnostics()
             )
         })
+    }
+
+    #[test]
+    fn completions_include_protocol_methods_for_constrained_type_vars() {
+        let hir = typed_hir("fn print<T: Display>(value: T) { value }");
+        let decl = match &hir.module.block.stmts[0].kind {
+            hir::StmtKind::FunctionDeclaration(decl) => decl,
+            other => panic!("expected FunctionDeclaration, got {other:?}"),
+        };
+        let type_var_id = match decl.parameters[0].type_annotation.kind {
+            TyKind::Var(id) => id,
+            ref other => panic!("expected constrained type variable, got {other:?}"),
+        };
+
+        let candidates =
+            complete_bound_protocol_methods(&hir.module.block, &hir.type_table, type_var_id);
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.name == "to_string"),
+            "expected Display-bound completions to include to_string, got: {candidates:?}"
+        );
     }
 
     // ── find_hir_expr_at_position ──────────────────────────────────────

--- a/crates/tlang_ast_lowering/src/expr.rs
+++ b/crates/tlang_ast_lowering/src/expr.rs
@@ -129,8 +129,12 @@ impl LoweringContext {
         // the outer protocol's `self`, so we must not rewrite field-access
         // calls inside the nested body.
         let saved_ctx = self.protocol_dispatch_ctx.take();
+        let saved_generic_ctx = self.generic_protocol_dispatch_ctx.take();
+        let saved_generic_ctx_by_name = self.generic_protocol_dispatch_ctx_by_name.take();
         let result = hir::ExprKind::FunctionExpression(Box::new(self.lower_fn_decl(decl)));
         self.protocol_dispatch_ctx = saved_ctx;
+        self.generic_protocol_dispatch_ctx = saved_generic_ctx;
+        self.generic_protocol_dispatch_ctx_by_name = saved_generic_ctx_by_name;
         result
     }
 
@@ -343,7 +347,7 @@ impl LoweringContext {
     }
 
     fn lower_call_expr(&mut self, node: &ast::node::CallExpression) -> hir::CallExpression {
-        // ── Implicit self-dispatch in protocol default implementations ──────────
+        // ── Implicit protocol dispatch rewrites ────────────────────────────────
         //
         // Inside a protocol default method body, a call of the form
         //   `self.method(arg1, arg2, …)`
@@ -358,46 +362,41 @@ impl LoweringContext {
             base,
             field,
         }) = &node.callee.kind
-            && let Some(ctx) = self.protocol_dispatch_ctx.as_ref()
+            && let ast::node::ExprKind::Path(path) = &base.kind
         {
-            // Identify the `self` receiver using compiler information:
-            //
-            // 1. Primary check – the path segment is the compiler's reserved
-            //    `kw::_Self` keyword ("self"), which the parser only emits for
-            //    the genuine `self` keyword, never for a regular identifier.
-            //
-            // 2. Reinforcing check – if semantic analysis has resolved the path
-            //    to a specific declaration (`Res::Def(node_id)`), verify that
-            //    the declaration is our tracked `self` parameter node.  This
-            //    handles shadowing: a `let self = …` binding would resolve to a
-            //    *different* NodeId and fail this check.
-            let is_self_receiver = if let ast::node::ExprKind::Path(path) = &base.kind {
-                if path.segments.len() == 1 && path.segments[0].as_str() == kw::_Self {
-                    // If the AST resolver has already set a Def node id,
-                    // use it for identity confirmation; otherwise fall back
-                    // to the keyword check alone.
-                    match path.res {
-                        ast::node::Res::Def(node_id) => node_id == ctx.self_param_node_id,
-                        ast::node::Res::Unresolved => true,
-                        ast::node::Res::PrimTy => false,
-                    }
-                } else {
-                    false
+            let protocol_ident = match path.res {
+                ast::node::Res::Def(node_id) => self
+                    .protocol_dispatch_ctx
+                    .as_ref()
+                    .filter(|ctx| ctx.self_param_node_id == node_id)
+                    .and_then(|ctx| ctx.method_dispatch_map.get(field.as_str()))
+                    .or_else(|| {
+                        self.generic_protocol_dispatch_ctx
+                            .as_ref()
+                            .and_then(|ctx| ctx.get(&node_id))
+                            .and_then(|dispatch_map| dispatch_map.get(field.as_str()))
+                    })
+                    .copied(),
+                ast::node::Res::Unresolved
+                    if path.segments.len() == 1 && path.segments[0].as_str() == kw::_Self =>
+                {
+                    self.protocol_dispatch_ctx
+                        .as_ref()
+                        .and_then(|ctx| ctx.method_dispatch_map.get(field.as_str()))
+                        .copied()
                 }
-            } else {
-                false
+                ast::node::Res::Unresolved if path.segments.len() == 1 => self
+                    .generic_protocol_dispatch_ctx_by_name
+                    .as_ref()
+                    .and_then(|ctx| ctx.get(path.segments[0].as_str()))
+                    .and_then(|dispatch_map| dispatch_map.get(field.as_str()))
+                    .copied(),
+                _ => None,
             };
 
-            if is_self_receiver
-                && let Some(&protocol_ident) = ctx.method_dispatch_map.get(field.as_str())
-            {
-                // Build the qualified callee path `OwningProtocol::method_name`.
-                // When the protocol method is defined with multiple arities,
-                // append the `/arity` suffix (total arity = 1 for `self` +
-                // the number of explicit arguments).
+            if let Some(target) = protocol_ident {
                 let method_str = field.as_str();
-                let total_arity = node.arguments.len() + 1; // +1 for self
-
+                let total_arity = node.arguments.len() + 1;
                 let method_segment_name = if self.has_multi_arity_fn(method_str, total_arity) {
                     format!("{method_str}/{total_arity}")
                 } else {
@@ -405,19 +404,21 @@ impl LoweringContext {
                 };
 
                 let span = node.callee.span;
-                let path = hir::Path::new(
+                let mut path = hir::Path::new(
                     vec![
-                        hir::PathSegment::from_str(protocol_ident.as_str(), protocol_ident.span),
+                        hir::PathSegment::from_str(target.ident.as_str(), target.ident.span),
                         hir::PathSegment::from_str(&method_segment_name, field.span),
                     ],
                     span,
                 );
-
+                if let Some(protocol_hir_id) = target.protocol_hir_id {
+                    path.res.set_hir_id(protocol_hir_id);
+                    path.res.set_binding_kind(hir::BindingKind::Enum);
+                }
                 let callee_hir = self.expr(span, hir::ExprKind::Path(Box::new(path)));
 
-                // The first argument is the `self` receiver; the rest follow.
-                let self_arg = self.lower_expr(base);
-                let mut arguments = vec![self_arg];
+                let receiver_arg = self.lower_expr(base);
+                let mut arguments = vec![receiver_arg];
                 arguments.extend(self.lower_exprs(&node.arguments));
 
                 return hir::CallExpression {

--- a/crates/tlang_ast_lowering/src/lib.rs
+++ b/crates/tlang_ast_lowering/src/lib.rs
@@ -61,23 +61,30 @@ pub(crate) struct ProtocolRegistryEntry {
 }
 
 const BUILTIN_PROTOCOL_HIR_ID_BASE: usize = 900_000_000;
-const BUILTIN_PROTOCOLS: &[(&str, &[&str])] = &[
-    ("Truthy", &["truthy"]),
-    ("Functor", &["map"]),
-    ("Accepts", &["accepts"]),
-    ("Iterable", &["iter"]),
-    ("Iterator", &["next"]),
-    ("Display", &["to_string"]),
-    ("Into", &["into"]),
-    ("TryInto", &["try_into"]),
+
+/// Builtin protocols with stable explicit `HirId` offsets.
+///
+/// The offset in each tuple is fixed and must match the corresponding entry in
+/// `tlang_typeck::builtin_protocols` (which uses the same base + same position
+/// order).  Using explicit offsets (instead of deriving them from position via
+/// `enumerate`) ensures that inserting or reordering entries in this list never
+/// silently shifts the identity of other protocols.
+const BUILTIN_PROTOCOLS: &[(usize, &str, &[&str])] = &[
+    (1, "Truthy", &["truthy"]),
+    (2, "Functor", &["map"]),
+    (3, "Accepts", &["accepts"]),
+    (4, "Iterable", &["iter"]),
+    (5, "Iterator", &["next"]),
+    (6, "Display", &["to_string"]),
+    (7, "Into", &["into"]),
+    (8, "TryInto", &["try_into"]),
 ];
 
 fn builtin_protocol_registry_entries() -> Vec<ProtocolRegistryEntry> {
     BUILTIN_PROTOCOLS
         .iter()
-        .enumerate()
-        .map(|(index, (name, methods))| ProtocolRegistryEntry {
-            hir_id: HirId::new(BUILTIN_PROTOCOL_HIR_ID_BASE + index + 1),
+        .map(|(offset, name, methods)| ProtocolRegistryEntry {
+            hir_id: HirId::new(BUILTIN_PROTOCOL_HIR_ID_BASE + offset),
             ident: Ident::new(name, Span::default()),
             methods: methods.iter().map(|method| (*method).to_string()).collect(),
             constraints: Vec::new(),

--- a/crates/tlang_ast_lowering/src/lib.rs
+++ b/crates/tlang_ast_lowering/src/lib.rs
@@ -21,28 +21,68 @@ use tlang_span::{HirId, HirIdAllocator, NodeId, Span, TypeVarId, TypeVarIdAlloca
 /// The dispatch map includes methods from the protocol itself **and** from all
 /// transitively-reachable constraint protocols, so that default bodies can freely
 /// call `self.eq(other)` when the protocol is `Ord : Eq`, for example.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProtocolDispatchTarget {
+    pub(crate) ident: Ident,
+    pub(crate) protocol_hir_id: Option<HirId>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ProtocolDispatchContext {
     /// Maps method name → the `Ident` of the protocol that declares that method.
     /// Includes the current protocol's own methods and all transitively-inherited
     /// constraint protocol methods (nearest/direct protocol wins on conflict).
-    pub(crate) method_dispatch_map: HashMap<String, Ident>,
+    pub(crate) method_dispatch_map: HashMap<String, ProtocolDispatchTarget>,
     /// The `NodeId` of the `self` parameter's pattern node in the current default
     /// method.  Stored here so that later passes can cross-check the identity of the
     /// `self` receiver without relying on string comparison alone.
     pub(crate) self_param_node_id: NodeId,
 }
 
+/// Active method-dispatch maps for generic function parameters constrained by
+/// one or more protocols.
+///
+/// Each entry maps a parameter-pattern `NodeId` to the protocol-method dispatch
+/// table that should be used for calls like `value.method(args...)`.
+pub(crate) type GenericProtocolDispatchContext =
+    HashMap<NodeId, HashMap<String, ProtocolDispatchTarget>>;
+
 /// Pre-scanned information about a protocol declaration, used to build
 /// `ProtocolDispatchContext` dispatch maps that include constraint methods.
 #[derive(Debug, Clone)]
 pub(crate) struct ProtocolRegistryEntry {
+    pub(crate) hir_id: HirId,
     /// The protocol's name identifier.
     pub(crate) ident: Ident,
     /// Names of methods directly declared in this protocol.
     pub(crate) methods: Vec<String>,
     /// Names of direct constraint protocols (e.g. `["Eq"]` for `Ord : Eq`).
     pub(crate) constraints: Vec<String>,
+}
+
+const BUILTIN_PROTOCOL_HIR_ID_BASE: usize = 900_000_000;
+const BUILTIN_PROTOCOLS: &[(&str, &[&str])] = &[
+    ("Truthy", &["truthy"]),
+    ("Functor", &["map"]),
+    ("Accepts", &["accepts"]),
+    ("Iterable", &["iter"]),
+    ("Iterator", &["next"]),
+    ("Display", &["to_string"]),
+    ("Into", &["into"]),
+    ("TryInto", &["try_into"]),
+];
+
+fn builtin_protocol_registry_entries() -> Vec<ProtocolRegistryEntry> {
+    BUILTIN_PROTOCOLS
+        .iter()
+        .enumerate()
+        .map(|(index, (name, methods))| ProtocolRegistryEntry {
+            hir_id: HirId::new(BUILTIN_PROTOCOL_HIR_ID_BASE + index + 1),
+            ident: Ident::new(name, Span::default()),
+            methods: methods.iter().map(|method| (*method).to_string()).collect(),
+            constraints: Vec::new(),
+        })
+        .collect()
 }
 
 /// Errors that can occur during AST-to-HIR lowering.
@@ -129,11 +169,21 @@ pub struct LoweringContext {
     /// Active protocol self-dispatch context, set while lowering a protocol
     /// default method body.  `None` outside of such bodies.
     pub(crate) protocol_dispatch_ctx: Option<ProtocolDispatchContext>,
+    /// Active constrained-generic dispatch context, set while lowering a
+    /// generic function body. `None` when no parameter uses protocol bounds.
+    pub(crate) generic_protocol_dispatch_ctx: Option<GenericProtocolDispatchContext>,
+    /// Name-based fallback for constrained-generic dispatch when semantic
+    /// resolution has not yet attached parameter `NodeId`s to identifier paths.
+    pub(crate) generic_protocol_dispatch_ctx_by_name:
+        Option<HashMap<String, HashMap<String, ProtocolDispatchTarget>>>,
     /// Pre-scanned registry of all protocol declarations in the module being
     /// lowered.  Populated by `lower_module` before any statement is lowered,
     /// so that `lower_protocol_decl` can look up constraint protocols' method
     /// lists when building a `ProtocolDispatchContext`.
     protocol_registry: HashMap<String, ProtocolRegistryEntry>,
+    /// Protocol registry keyed by lowered declaration `HirId` for lookups that
+    /// already carry resolved protocol identities.
+    protocol_registry_by_hir_id: HashMap<HirId, ProtocolRegistryEntry>,
     /// HirIds of `CallExpression` nodes that were desugared from the `|>`
     /// pipeline operator.  Collected during lowering and forwarded to
     /// [`hir::LowerResultMeta`] so that downstream passes can identify
@@ -162,7 +212,10 @@ impl LoweringContext {
             current_symbol_table: root_symbol_table,
             errors: Vec::new(),
             protocol_dispatch_ctx: None,
+            generic_protocol_dispatch_ctx: None,
+            generic_protocol_dispatch_ctx_by_name: None,
             protocol_registry: HashMap::default(),
+            protocol_registry_by_hir_id: HashMap::default(),
             pipeline_call_ids: HashSet::default(),
             type_var_id_allocator: TypeVarIdAllocator::new(1),
             type_param_scopes: Vec::new(),
@@ -386,18 +439,29 @@ impl LoweringContext {
             module.statements.len()
         );
 
+        for entry in builtin_protocol_registry_entries() {
+            self.protocol_registry
+                .entry(entry.ident.to_string())
+                .or_insert_with(|| entry.clone());
+            self.protocol_registry_by_hir_id
+                .entry(entry.hir_id)
+                .or_insert(entry);
+        }
+
         // Pre-scan all protocol declarations so that `lower_protocol_decl` can
         // look up constraint protocol methods when building dispatch contexts.
         for stmt in &module.statements {
             if let ast::node::StmtKind::ProtocolDeclaration(decl) = &stmt.kind {
-                self.protocol_registry.insert(
-                    decl.name.to_string(),
-                    ProtocolRegistryEntry {
-                        ident: decl.name,
-                        methods: decl.methods.iter().map(|m| m.name.to_string()).collect(),
-                        constraints: decl.constraints.iter().map(|c| c.to_string()).collect(),
-                    },
-                );
+                let hir_id = self.lower_node_id(stmt.id);
+                let entry = ProtocolRegistryEntry {
+                    hir_id,
+                    ident: decl.name,
+                    methods: decl.methods.iter().map(|m| m.name.to_string()).collect(),
+                    constraints: decl.constraints.iter().map(|c| c.to_string()).collect(),
+                };
+                self.protocol_registry
+                    .insert(decl.name.to_string(), entry.clone());
+                self.protocol_registry_by_hir_id.insert(hir_id, entry);
             }
         }
 
@@ -432,12 +496,21 @@ impl LoweringContext {
         current_protocol_ident: Ident,
         current_protocol_methods: &[String],
         constraints: &[String],
-    ) -> HashMap<String, Ident> {
-        let mut map: HashMap<String, Ident> = HashMap::new();
+    ) -> HashMap<String, ProtocolDispatchTarget> {
+        let mut map: HashMap<String, ProtocolDispatchTarget> = HashMap::new();
 
         // Current protocol's own methods (highest priority).
         for method_name in current_protocol_methods {
-            map.insert(method_name.clone(), current_protocol_ident);
+            map.insert(
+                method_name.clone(),
+                ProtocolDispatchTarget {
+                    ident: current_protocol_ident,
+                    protocol_hir_id: self
+                        .protocol_registry
+                        .get(current_protocol_ident.as_str())
+                        .map(|entry| entry.hir_id),
+                },
+            );
         }
 
         // Transitively add constraint protocol methods using FIFO traversal so
@@ -454,11 +527,92 @@ impl LoweringContext {
             if let Some(entry) = self.protocol_registry.get(&constraint_name) {
                 for method_name in &entry.methods {
                     // or_insert: current protocol and earlier constraints win.
-                    map.entry(method_name.clone()).or_insert(entry.ident);
+                    map.entry(method_name.clone())
+                        .or_insert(ProtocolDispatchTarget {
+                            ident: entry.ident,
+                            protocol_hir_id: Some(entry.hir_id),
+                        });
                 }
                 // Queue this constraint's own constraints for transitive lookup.
                 for nested in &entry.constraints {
                     to_visit.push_back(nested.clone());
+                }
+            }
+        }
+
+        map
+    }
+
+    /// Builds a method-dispatch map for a set of protocol bounds.
+    ///
+    /// Direct bounds are visited in source order, then each protocol's
+    /// transitive constraints are traversed breadth-first. The first protocol
+    /// that defines a given method wins.
+    pub(crate) fn build_bound_protocol_dispatch_map(
+        &self,
+        bounds: &[hir::Ty],
+    ) -> HashMap<String, ProtocolDispatchTarget> {
+        let mut map = HashMap::new();
+        let mut to_visit: VecDeque<(Option<HirId>, String)> = bounds
+            .iter()
+            .filter_map(|bound| match &bound.kind {
+                hir::TyKind::Path(path, _) => {
+                    Some((path.res.hir_id().or(bound.res), path.join("::")))
+                }
+                _ => None,
+            })
+            .collect();
+        let mut visited = HashSet::new();
+
+        while let Some((protocol_hir_id, protocol_name)) = to_visit.pop_front() {
+            if !visited.insert(
+                protocol_hir_id.map_or_else(|| protocol_name.clone(), |hir_id| hir_id.to_string()),
+            ) {
+                continue;
+            }
+
+            if let Some(entry) = protocol_hir_id
+                .and_then(|hir_id| self.protocol_registry_by_hir_id.get(&hir_id))
+                .or_else(|| self.protocol_registry.get(&protocol_name))
+            {
+                for method_name in &entry.methods {
+                    map.entry(method_name.clone())
+                        .or_insert(ProtocolDispatchTarget {
+                            ident: entry.ident,
+                            protocol_hir_id: Some(entry.hir_id),
+                        });
+                }
+                for nested in &entry.constraints {
+                    to_visit.push_back((None, nested.clone()));
+                }
+                continue;
+            }
+
+            let prefix = format!("{protocol_name}::");
+            for scope in self.symbol_tables.values() {
+                let Ok(symbols) = scope.read() else {
+                    continue;
+                };
+
+                for symbol in symbols.get_all_local_symbols() {
+                    if !matches!(symbol.kind, DefKind::ProtocolMethod(_))
+                        || !symbol.name.starts_with(prefix.as_str())
+                    {
+                        continue;
+                    }
+
+                    let Some(method_name) = symbol.name.strip_prefix(prefix.as_str()) else {
+                        continue;
+                    };
+                    if method_name.is_empty() {
+                        continue;
+                    }
+
+                    map.entry(method_name.to_string())
+                        .or_insert(ProtocolDispatchTarget {
+                            ident: Ident::new(&protocol_name, Span::default()),
+                            protocol_hir_id: None,
+                        });
                 }
             }
         }
@@ -564,7 +718,29 @@ impl LoweringContext {
                 .map(|param| this.lower_fn_param(param))
                 .collect::<Vec<_>>();
             this.seed_dot_method_receiver_type(&name, &owner_type_params, &mut parameters);
+            let dispatch_type_params = owner_type_params
+                .iter()
+                .chain(type_params.iter())
+                .cloned()
+                .collect::<Vec<_>>();
+            let generic_dispatch_ctx = this.build_generic_protocol_dispatch_context_from_params(
+                &decl.parameters,
+                &dispatch_type_params,
+            );
+            let generic_dispatch_ctx_by_name = this
+                .build_generic_protocol_dispatch_context_by_name_from_params(
+                    &decl.parameters,
+                    &dispatch_type_params,
+                );
+            let saved_generic_ctx = this.generic_protocol_dispatch_ctx.take();
+            let saved_generic_ctx_by_name = this.generic_protocol_dispatch_ctx_by_name.take();
+            this.generic_protocol_dispatch_ctx =
+                (!generic_dispatch_ctx.is_empty()).then_some(generic_dispatch_ctx);
+            this.generic_protocol_dispatch_ctx_by_name =
+                (!generic_dispatch_ctx_by_name.is_empty()).then_some(generic_dispatch_ctx_by_name);
             let body = this.lower_block_in_current_scope(&decl.body);
+            this.generic_protocol_dispatch_ctx = saved_generic_ctx;
+            this.generic_protocol_dispatch_ctx_by_name = saved_generic_ctx_by_name;
             let return_type = this.lower_ty(decl.return_type_annotation.as_ref());
 
             this.pop_type_param_scope();
@@ -743,6 +919,67 @@ impl LoweringContext {
         hir_params
     }
 
+    fn build_generic_protocol_dispatch_context_from_params(
+        &mut self,
+        ast_parameters: &[ast::node::FunctionParameter],
+        type_params: &[hir::TypeParam],
+    ) -> GenericProtocolDispatchContext {
+        let dispatch_by_type_var: HashMap<_, _> = type_params
+            .iter()
+            .filter_map(|type_param| {
+                let dispatch_map = self.build_bound_protocol_dispatch_map(&type_param.bounds);
+                (!dispatch_map.is_empty()).then_some((type_param.type_var_id, dispatch_map))
+            })
+            .collect();
+
+        ast_parameters
+            .iter()
+            .filter_map(|param| {
+                let lowered_ty = self.lower_ty(param.type_annotation.as_ref());
+                let hir::TyKind::Var(type_var_id) = lowered_ty.kind else {
+                    return None;
+                };
+
+                dispatch_by_type_var
+                    .get(&type_var_id)
+                    .cloned()
+                    .map(|dispatch_map| (param.pattern.id, dispatch_map))
+            })
+            .collect()
+    }
+
+    fn build_generic_protocol_dispatch_context_by_name_from_params(
+        &mut self,
+        ast_parameters: &[ast::node::FunctionParameter],
+        type_params: &[hir::TypeParam],
+    ) -> HashMap<String, HashMap<String, ProtocolDispatchTarget>> {
+        let dispatch_by_type_var: HashMap<_, _> = type_params
+            .iter()
+            .filter_map(|type_param| {
+                let dispatch_map = self.build_bound_protocol_dispatch_map(&type_param.bounds);
+                (!dispatch_map.is_empty()).then_some((type_param.type_var_id, dispatch_map))
+            })
+            .collect();
+
+        ast_parameters
+            .iter()
+            .filter_map(|param| {
+                let ast::node::PatKind::Identifier(ident) = &param.pattern.kind else {
+                    return None;
+                };
+                let lowered_ty = self.lower_ty(param.type_annotation.as_ref());
+                let hir::TyKind::Var(type_var_id) = lowered_ty.kind else {
+                    return None;
+                };
+
+                dispatch_by_type_var
+                    .get(&type_var_id)
+                    .cloned()
+                    .map(|dispatch_map| (ident.to_string(), dispatch_map))
+            })
+            .collect()
+    }
+
     /// Pop the most recently pushed type parameter scope. Must be called after
     /// lowering the body that was covered by the corresponding
     /// [`lower_type_params`] call.
@@ -862,8 +1099,12 @@ impl LoweringContext {
                 return hir::TyKind::Var(type_var_id);
             }
         }
+        let mut lowered_path = self.lower_path(path);
+        if let ast::node::Res::Def(node_id) = path.res {
+            lowered_path.res.set_hir_id(self.lower_node_id(node_id));
+        }
         hir::TyKind::Path(
-            self.lower_path(path),
+            lowered_path,
             params
                 .iter()
                 .map(|param| self.lower_ty(Some(param)))

--- a/crates/tlang_ast_lowering/src/stmt.rs
+++ b/crates/tlang_ast_lowering/src/stmt.rs
@@ -5,6 +5,7 @@ use tlang_ast as ast;
 use tlang_ast::node::{ConstDeclaration, FunctionDeclaration, Ident, LetDeclaration};
 use tlang_defs::DefKind;
 use tlang_hir as hir;
+use tlang_span::{NodeId, Span};
 
 use crate::{LoweringContext, ProtocolDispatchContext};
 
@@ -47,6 +48,10 @@ fn same_ast_ty_shape(lhs: &ast::node::Ty, rhs: &ast::node::Ty) -> bool {
         }
         _ => false,
     }
+}
+
+fn is_synthetic_inferred_ast_ty(ty: &ast::node::Ty) -> bool {
+    ty.id == NodeId::new(1) && ty.span == Span::default()
 }
 
 impl LoweringContext {
@@ -446,7 +451,7 @@ impl LoweringContext {
     fn lower_protocol_method_signature(
         &mut self,
         method: &ast::node::ProtocolMethodSignature,
-        method_dispatch_map: &HashMap<String, Ident>,
+        method_dispatch_map: &HashMap<String, crate::ProtocolDispatchTarget>,
     ) -> hir::ProtocolMethodSignature {
         let type_params = self.lower_type_params(&method.type_params);
         let has_body = method.body.is_some();
@@ -779,7 +784,10 @@ impl LoweringContext {
                 } else {
                     hir::Ty::default()
                 };
-                let has_type_annotation = !matches!(type_annotation.kind, hir::TyKind::Unknown);
+                let has_type_annotation = type_annotations
+                    .iter()
+                    .flatten()
+                    .any(|annotation| !is_synthetic_inferred_ast_ty(annotation));
 
                 hir::FunctionParameter {
                     hir_id: self.unique_id(),
@@ -920,9 +928,39 @@ impl LoweringContext {
             let fn_name_str = this.fn_name_or_error(&decls[0]);
             this.define_function_symbols(hir_id, &fn_name_str, &decls[0], &params);
 
+            let dispatch_type_params = owner_type_params
+                .iter()
+                .chain(type_params.iter())
+                .cloned()
+                .collect::<Vec<_>>();
+            let mut generic_dispatch_ctx = crate::GenericProtocolDispatchContext::default();
+            let mut generic_dispatch_ctx_by_name = HashMap::new();
+            for decl in decls {
+                generic_dispatch_ctx.extend(
+                    this.build_generic_protocol_dispatch_context_from_params(
+                        &decl.parameters,
+                        &dispatch_type_params,
+                    ),
+                );
+                generic_dispatch_ctx_by_name.extend(
+                    this.build_generic_protocol_dispatch_context_by_name_from_params(
+                        &decl.parameters,
+                        &dispatch_type_params,
+                    ),
+                );
+            }
+            let saved_generic_ctx = this.generic_protocol_dispatch_ctx.take();
+            let saved_generic_ctx_by_name = this.generic_protocol_dispatch_ctx_by_name.take();
+            this.generic_protocol_dispatch_ctx =
+                (!generic_dispatch_ctx.is_empty()).then_some(generic_dispatch_ctx);
+            this.generic_protocol_dispatch_ctx_by_name =
+                (!generic_dispatch_ctx_by_name.is_empty()).then_some(generic_dispatch_ctx_by_name);
+
             let match_value = this.create_match_value(&params, span);
 
             let match_arms = this.create_match_arms(decls, leading_comments);
+            this.generic_protocol_dispatch_ctx = saved_generic_ctx;
+            this.generic_protocol_dispatch_ctx_by_name = saved_generic_ctx_by_name;
 
             // Inherit the return type from the first clause that has an
             // explicit annotation.  Must happen before `pop_type_param_scope`

--- a/crates/tlang_ast_lowering/tests/protocol_self_dispatch.rs
+++ b/crates/tlang_ast_lowering/tests/protocol_self_dispatch.rs
@@ -136,3 +136,24 @@ fn test_protocol_self_dispatch_not_applied_in_nested_fn() {
         "f(self) should remain as-is:\n{output}"
     );
 }
+
+#[test]
+fn test_protocol_dispatch_on_constrained_generic_parameter() {
+    let hir = hir_from_str(
+        r#"
+            fn print<T: Display>(value: T) {
+                log(value.to_string())
+            }
+        "#,
+    );
+
+    let output = pretty_print(&hir);
+    assert!(
+        output.contains("Display::to_string(value)"),
+        "expected constrained generic call to lower to protocol dispatch:\n{output}"
+    );
+    assert!(
+        !output.contains("value.to_string"),
+        "expected dot call to be rewritten during lowering:\n{output}"
+    );
+}

--- a/crates/tlang_cli/src/commands/build.rs
+++ b/crates/tlang_cli/src/commands/build.rs
@@ -133,7 +133,7 @@ fn generate_module_code(
 ) -> Option<String> {
     let mut hir_module = compiled.hir.clone();
     let mut optimizer = CompileTargetHirOptimizer::JavaScript(
-        tlang_codegen_js::js_hir_opt::JsHirOptimizer::default(),
+        tlang_codegen_js::js_hir_opt::JsHirOptimizer::pre_typecheck(),
     );
     let mut ctx = compiled.lower_meta.clone().into();
     if let Err(err) = run_hir_passes(&mut optimizer, &mut hir_module, &mut ctx) {
@@ -151,6 +151,12 @@ fn generate_module_code(
     // ExhaustiveEnumMatch must run after type checking.
     let mut exhaustive_enum = tlang_hir_opt::ExhaustiveEnumMatch::default();
     if let Err(err) = exhaustive_enum.optimize_hir(&mut hir_module, &mut ctx) {
+        eprint!("{}", render_ice(&err));
+        return None;
+    }
+
+    let mut js_post_optimizer = tlang_codegen_js::js_hir_opt::JsHirOptimizer::post_typecheck();
+    if let Err(err) = js_post_optimizer.optimize_hir(&mut hir_module, &mut ctx) {
         eprint!("{}", render_ice(&err));
         return None;
     }

--- a/crates/tlang_cli/src/commands/compile/mod.rs
+++ b/crates/tlang_cli/src/commands/compile/mod.rs
@@ -113,7 +113,7 @@ fn compile_to_hir(
     let mut ctx = meta.into();
 
     let mut optimizer = if matches!(target, CompileTargetArg::Js) {
-        CompileTargetHirOptimizer::JavaScript(JsHirOptimizer::default())
+        CompileTargetHirOptimizer::JavaScript(JsHirOptimizer::pre_typecheck())
     } else {
         CompileTargetHirOptimizer::Interpreter(HirOptimizer::default())
     };
@@ -143,6 +143,14 @@ fn compile_to_hir(
     if let Err(err) = exhaustive_enum.optimize_hir(&mut module, &mut ctx) {
         eprint!("{}", render_ice(&err));
         std::process::exit(1);
+    }
+
+    if matches!(target, CompileTargetArg::Js) {
+        let mut js_post_optimizer = JsHirOptimizer::post_typecheck();
+        if let Err(err) = js_post_optimizer.optimize_hir(&mut module, &mut ctx) {
+            eprint!("{}", render_ice(&err));
+            std::process::exit(1);
+        }
     }
 
     Ok(module)

--- a/crates/tlang_codegen_js/src/js_hir_opt.rs
+++ b/crates/tlang_codegen_js/src/js_hir_opt.rs
@@ -93,6 +93,24 @@ impl JsHirOptimizer {
         Self(HirOptGroup::new("root", passes))
     }
 
+    pub fn pre_typecheck() -> Self {
+        Self::new(vec![
+            Box::new(hir_opt::tail_call_validation::TailPositionAnalysis::default()),
+            Box::new(hir_opt::symbol_resolution::SymbolResolution::default()),
+            Box::new(TailCallSelfReferenceValidation::default()),
+        ])
+    }
+
+    pub fn post_typecheck() -> Self {
+        Self::new(vec![
+            Box::new(JsAnfTransform::default()),
+            Box::new(JsAnfReturnOpt::default()),
+            Box::new(BooleanReturnSimplification::default()),
+            Box::new(hir_opt::constant_folding::ConstantFolding::default()),
+            Box::new(hir_opt::dead_code_elimination::DeadCodeElimination::default()),
+        ])
+    }
+
     pub fn add_pass(&mut self, pass: Box<dyn HirPass>) {
         self.0.add_pass(pass);
     }

--- a/crates/tlang_codegen_js/tests/common/mod.rs
+++ b/crates/tlang_codegen_js/tests/common/mod.rs
@@ -1,6 +1,6 @@
-use tlang_codegen_js::JsAnfTransform;
 use tlang_codegen_js::generator::CodegenJS;
-use tlang_codegen_js::js_hir_opt::{DefaultJsOptimizations, JsHirOptimizer};
+use tlang_codegen_js::js_hir_opt::JsHirOptimizer;
+use tlang_codegen_js::{BooleanReturnSimplification, JsAnfReturnOpt, JsAnfTransform};
 use tlang_defs::DefKind;
 use tlang_hir_opt::HirPass;
 use tlang_hir_opt::symbol_resolution::SymbolResolution;
@@ -78,13 +78,7 @@ pub fn compile_src_with_warnings(
             .expect("lowering should succeed");
 
             if options.optimize {
-                let mut optimizer = JsHirOptimizer::from(
-                    DefaultJsOptimizations::default()
-                        // DeadCodeElimination is intentionally excluded.
-                        // These tests compile isolated snippets (REPL-like), so
-                        // top-level declarations would be incorrectly removed by DCE.
-                        .without("DeadCodeElimination"),
-                );
+                let mut optimizer = JsHirOptimizer::pre_typecheck();
                 let mut ctx = meta.into();
                 optimizer
                     .optimize_hir(&mut module, &mut ctx)
@@ -96,6 +90,16 @@ pub fn compile_src_with_warnings(
                     exhaustive_enum
                         .optimize_hir(&mut module, &mut ctx)
                         .expect("exhaustive enum optimization failed");
+
+                    let mut js_optimizer = JsHirOptimizer::new(vec![
+                        Box::new(JsAnfTransform::default()),
+                        Box::new(JsAnfReturnOpt::default()),
+                        Box::new(BooleanReturnSimplification::default()),
+                        Box::new(tlang_hir_opt::constant_folding::ConstantFolding::default()),
+                    ]);
+                    js_optimizer
+                        .optimize_hir(&mut module, &mut ctx)
+                        .expect("post-typecheck JS optimization failed");
                 }
             } else {
                 // Even without full optimization, SymbolResolution must run to

--- a/crates/tlang_lsp_server/src/server.rs
+++ b/crates/tlang_lsp_server/src/server.rs
@@ -1790,6 +1790,71 @@ mod tests {
     }
 
     #[test]
+    fn hover_and_goto_work_for_protocol_methods_on_constrained_generics() {
+        let source = "protocol Printable { fn show(self) -> String }\nfn print<T: Printable>(value: T) { log(value.show()) }";
+        let mut state = setup_server_with_source(source);
+        let uri = test_uri();
+        let call_col = source
+            .lines()
+            .nth(1)
+            .and_then(|line| line.rfind("show"))
+            .expect("call site should contain show") as u32;
+        let decl_col = source
+            .lines()
+            .next()
+            .and_then(|line| line.find("show"))
+            .expect("protocol declaration should contain show") as u32;
+        let pos = lsp_types::Position {
+            line: 1,
+            character: call_col,
+        };
+
+        let hover = futures::executor::block_on(ServerState::on_hover(
+            &mut state,
+            HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri: uri.clone() },
+                    position: pos,
+                },
+                work_done_progress_params: Default::default(),
+            },
+        ))
+        .expect("hover request should succeed")
+        .expect("hover should be present");
+        match hover.contents {
+            lsp_types::HoverContents::Scalar(lsp_types::MarkedString::String(s)) => {
+                assert!(
+                    s.contains("show"),
+                    "expected hover to describe the protocol method, got: {s}"
+                );
+            }
+            _ => panic!("unexpected hover contents format"),
+        }
+
+        let goto = futures::executor::block_on(ServerState::on_goto_definition(
+            &mut state,
+            GotoDefinitionParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri: uri.clone() },
+                    position: pos,
+                },
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            },
+        ))
+        .expect("goto request should succeed")
+        .expect("goto should be present");
+
+        match goto {
+            GotoDefinitionResponse::Scalar(loc) => {
+                assert_eq!(loc.range.start.line, 0);
+                assert_eq!(loc.range.start.character, decl_col);
+            }
+            _ => panic!("expected scalar location"),
+        }
+    }
+
+    #[test]
     fn references_return_locations_and_respect_include_declaration() {
         let source = "fn id(value) { value }\nlet value = id(1);\nid(value);";
         let mut state = setup_server_with_source(source);

--- a/crates/tlang_typeck/src/builtin_protocols.rs
+++ b/crates/tlang_typeck/src/builtin_protocols.rs
@@ -6,7 +6,7 @@
 //! runtime (`tlang_memory`).
 
 use tlang_ast::node::Ident;
-use tlang_span::Span;
+use tlang_span::{HirId, Span};
 
 use crate::type_table::{AssociatedTypeInfo, ProtocolInfo, ProtocolMethodInfo};
 
@@ -112,6 +112,8 @@ static BUILTIN_PROTOCOLS: &[BuiltinProtocol] = &[
     },
 ];
 
+const BUILTIN_PROTOCOL_HIR_ID_BASE: usize = 900_000_000;
+
 fn ident(name: &str) -> Ident {
     Ident::new(name, Span::default())
 }
@@ -119,6 +121,14 @@ fn ident(name: &str) -> Ident {
 /// Returns `true` if `name` is a builtin native protocol.
 pub fn is_builtin_protocol(name: &str) -> bool {
     BUILTIN_PROTOCOLS.iter().any(|p| p.name == name)
+}
+
+/// Returns the stable synthetic `HirId` assigned to a builtin protocol.
+pub fn builtin_hir_id(name: &str) -> Option<HirId> {
+    BUILTIN_PROTOCOLS
+        .iter()
+        .position(|protocol| protocol.name == name)
+        .map(|index| HirId::new(BUILTIN_PROTOCOL_HIR_ID_BASE + index + 1))
 }
 
 /// Return [`ProtocolInfo`] entries for all builtin native protocols.
@@ -214,6 +224,7 @@ fn to_protocol_info(p: &BuiltinProtocol) -> ProtocolInfo {
         .collect();
 
     ProtocolInfo {
+        hir_id: builtin_hir_id(p.name),
         name: ident(p.name),
         type_param_var_ids: Vec::new(),
         methods,

--- a/crates/tlang_typeck/src/lib.rs
+++ b/crates/tlang_typeck/src/lib.rs
@@ -10,7 +10,7 @@ mod type_table;
 mod typing_context;
 pub mod unification;
 
-pub use type_checker::TypeChecker;
+pub use type_checker::{TypeChecker, match_lowered_param_pat};
 pub use type_error::TypeError;
 pub use type_table::{
     EnumInfo, ImplInfo, ProtocolInfo, ProtocolMethodInfo, StructInfo, TypeInfo, TypeTable,

--- a/crates/tlang_typeck/src/type_checker.rs
+++ b/crates/tlang_typeck/src/type_checker.rs
@@ -410,6 +410,43 @@ impl TypeChecker {
         };
     }
 
+    fn seed_match_lowered_parameter_types(&self, decl: &mut hir::FunctionDeclaration) {
+        if !decl.is_match_lowered {
+            return;
+        }
+
+        let Some(body_expr) = decl.body.expr.as_ref() else {
+            return;
+        };
+
+        let inferred: Vec<Option<TyKind>> = decl
+            .parameters
+            .iter()
+            .enumerate()
+            .map(|(index, param)| {
+                if param.has_type_annotation
+                    || !matches!(param.type_annotation.kind, TyKind::Unknown)
+                {
+                    None
+                } else {
+                    infer_match_lowered_param_ty(
+                        decl,
+                        body_expr,
+                        index,
+                        param.hir_id,
+                        &self.type_table,
+                    )
+                }
+            })
+            .collect();
+
+        for (param, inferred) in decl.parameters.iter_mut().zip(inferred) {
+            if let Some(kind) = inferred {
+                param.type_annotation.kind = kind;
+            }
+        }
+    }
+
     /// Resolve the result type of `base[index]`.
     ///
     /// Only slice indexing currently has aligned type-checker and runtime
@@ -1224,6 +1261,13 @@ impl TypeChecker {
 
         let (protocol_name, method_name) = self.protocol_dispatch_parts(path)?;
         let receiver_ty = &call.arguments[0].ty.kind;
+        if let Some(fn_ty) = self.resolve_bounded_type_var_protocol_dispatch_callee_type(
+            &protocol_name,
+            &method_name,
+            receiver_ty,
+        ) {
+            return Some(fn_ty);
+        }
         let receiver_type_name = Self::receiver_dispatch_type_name(receiver_ty)?;
 
         self.resolve_impl_protocol_dispatch_callee_type(
@@ -1240,6 +1284,57 @@ impl TypeChecker {
                 &receiver_type_name,
             )
         })
+    }
+
+    fn resolve_bounded_type_var_protocol_dispatch_callee_type(
+        &self,
+        protocol_name: &str,
+        method_name: &str,
+        receiver_ty: &TyKind,
+    ) -> Option<TyKind> {
+        let TyKind::Var(type_var_id) = receiver_ty else {
+            return None;
+        };
+
+        let proto_info = self.type_table.get_protocol_info(protocol_name)?;
+        let method = proto_info
+            .methods
+            .iter()
+            .find(|candidate| candidate.name.as_str() == method_name)?;
+        let bounds = self.type_table.get_type_param_bounds(*type_var_id)?;
+        let bound = bounds.iter().find(|bound| {
+            self.type_table
+                .resolve_protocol_bound(bound)
+                .is_some_and(|(bound_protocol, _)| bound_protocol.hir_id == proto_info.hir_id)
+        })?;
+
+        let mut type_bindings = HashMap::new();
+        if let TyKind::Path(_, type_args) = &bound.kind {
+            for (proto_type_param, type_arg) in proto_info.type_param_var_ids.iter().zip(type_args)
+            {
+                type_bindings.insert(*proto_type_param, type_arg.kind.clone());
+            }
+        }
+
+        let mut param_tys: Vec<Ty> = method
+            .param_tys
+            .iter()
+            .map(|ty| Ty {
+                kind: substitute_type_vars(&ty.kind, &type_bindings),
+                ..ty.clone()
+            })
+            .collect();
+        if let Some(self_param) = param_tys.first_mut() {
+            self_param.kind = receiver_ty.clone();
+        }
+
+        Some(TyKind::Fn(
+            param_tys,
+            Box::new(Ty {
+                kind: substitute_type_vars(&method.return_ty.kind, &type_bindings),
+                ..method.return_ty.clone()
+            }),
+        ))
     }
 
     fn resolve_impl_protocol_dispatch_callee_type(
@@ -1422,12 +1517,19 @@ impl TypeChecker {
         }
 
         let method_name = path.last_ident().as_str().to_string();
-        let protocol_name = path.segments[..path.segments.len() - 1]
-            .iter()
-            .map(|segment| segment.ident.as_str())
-            .collect::<Vec<_>>()
-            .join("::");
-        let proto_info = self.type_table.get_protocol_info(&protocol_name)?;
+        let proto_info = path
+            .res
+            .hir_id()
+            .and_then(|hir_id| self.type_table.get_protocol_info_by_hir_id(hir_id))
+            .or_else(|| {
+                let protocol_name = path.segments[..path.segments.len() - 1]
+                    .iter()
+                    .map(|segment| segment.ident.as_str())
+                    .collect::<Vec<_>>()
+                    .join("::");
+                self.type_table.get_protocol_info(&protocol_name)
+            })?;
+        let protocol_name = proto_info.name.to_string();
         proto_info
             .methods
             .iter()
@@ -2472,6 +2574,7 @@ impl TypeChecker {
     /// Register a struct declaration in the type table: store field metadata
     /// and register a constructor function type `Fn(field_tys…) → Path(Struct)`.
     fn register_struct_declaration(&mut self, decl: &hir::StructDeclaration) {
+        self.register_type_param_bounds(&decl.type_params);
         let mut struct_path = hir::Path::new(
             vec![hir::PathSegment { ident: decl.name }],
             tlang_span::Span::default(),
@@ -2519,6 +2622,7 @@ impl TypeChecker {
     /// Register an enum declaration in the type table: store variant metadata
     /// and register each variant constructor.
     fn register_enum_declaration(&mut self, decl: &hir::EnumDeclaration) {
+        self.register_type_param_bounds(&decl.type_params);
         let mut enum_path = hir::Path::new(
             vec![hir::PathSegment { ident: decl.name }],
             tlang_span::Span::default(),
@@ -2599,6 +2703,7 @@ impl TypeChecker {
     /// Register a protocol declaration in the type table: store method
     /// signatures and constraint protocol names.
     fn register_protocol_declaration(&mut self, decl: &hir::ProtocolDeclaration) {
+        self.register_type_param_bounds(&decl.type_params);
         let methods: Vec<ProtocolMethodInfo> = decl
             .methods
             .iter()
@@ -2623,6 +2728,7 @@ impl TypeChecker {
             })
             .collect();
         self.type_table.insert_protocol_info(ProtocolInfo {
+            hir_id: Some(decl.hir_id),
             name: decl.name,
             type_param_var_ids: decl
                 .type_params
@@ -2652,6 +2758,13 @@ impl TypeChecker {
                     },
                 },
             );
+        }
+    }
+
+    fn register_type_param_bounds(&mut self, type_params: &[hir::TypeParam]) {
+        for type_param in type_params {
+            self.type_table
+                .insert_type_param_bounds(type_param.type_var_id, type_param.bounds.clone());
         }
     }
 
@@ -3526,6 +3639,8 @@ impl TypeChecker {
         let enclosing = self.current_context();
         let closure_ctx = TypingContext::for_closure(decl, enclosing);
         self.push_context(closure_ctx);
+        self.register_type_param_bounds(&decl.owner_type_params);
+        self.register_type_param_bounds(&decl.type_params);
 
         self.register_function_signature(decl);
 
@@ -3608,8 +3723,11 @@ impl TypeChecker {
     /// and impl block methods.
     fn typecheck_function_decl(&mut self, decl: &mut hir::FunctionDeclaration) {
         self.seed_dot_method_receiver_type(decl);
+        self.seed_match_lowered_parameter_types(decl);
         let fn_ctx = TypingContext::for_function(decl);
         self.push_context(fn_ctx);
+        self.register_type_param_bounds(&decl.owner_type_params);
+        self.register_type_param_bounds(&decl.type_params);
         self.register_function_signature(decl);
 
         for param in &decl.parameters {
@@ -3631,47 +3749,194 @@ impl TypeChecker {
         self.flush_local_inference_errors();
         self.check_function_body_return(decl);
 
-        if matches!(decl.return_type.kind, TyKind::Unknown) {
-            let body_ty = decl
-                .body
-                .expr
-                .as_ref()
-                .map(|e| e.ty.kind.clone())
-                .or_else(|| self.infer_return_type_from_observed())
-                .unwrap_or_else(|| decl.return_type.kind.clone());
+        let body_ty = decl
+            .body
+            .expr
+            .as_ref()
+            .map(|e| e.ty.kind.clone())
+            .or_else(|| self.infer_return_type_from_observed())
+            .unwrap_or_else(|| decl.return_type.kind.clone());
 
-            // Write the inferred return type back so inlay hints can read it.
-            if !decl.has_return_type {
-                decl.return_type.kind = body_ty.clone();
-            }
-
-            let signature_ret_ty = if decl.has_return_type {
-                decl.return_type.kind.clone()
-            } else {
-                body_ty.clone()
-            };
-
-            let param_tys: Vec<Ty> = decl
-                .parameters
-                .iter()
-                .map(|p| p.type_annotation.clone())
-                .collect();
-            let fn_ty = Self::make_fn_ty(param_tys, signature_ret_ty);
-            self.type_table.insert(
-                decl.hir_id,
-                TypeInfo {
-                    ty: Ty {
-                        kind: fn_ty,
-                        ..Ty::default()
-                    },
-                },
-            );
+        // Write the inferred return type back so inlay hints can read it.
+        if matches!(decl.return_type.kind, TyKind::Unknown) && !decl.has_return_type {
+            decl.return_type.kind = body_ty.clone();
         }
+
+        let signature_ret_ty = if decl.has_return_type {
+            decl.return_type.kind.clone()
+        } else {
+            body_ty
+        };
+
+        let param_tys: Vec<Ty> = decl
+            .parameters
+            .iter()
+            .map(|p| p.type_annotation.clone())
+            .collect();
+        let fn_ty = Self::make_fn_ty(param_tys, signature_ret_ty);
+        self.type_table.insert(
+            decl.hir_id,
+            TypeInfo {
+                ty: Ty {
+                    kind: fn_ty,
+                    ..Ty::default()
+                },
+            },
+        );
 
         self.observed_return_types.pop();
         self.return_type_stack.pop();
         self.pop_context();
     }
+}
+
+fn match_lowered_param_pat(pat: &hir::Pat, index: usize, arity: usize) -> Option<&hir::Pat> {
+    if arity == 1 {
+        return Some(pat);
+    }
+
+    match &pat.kind {
+        hir::PatKind::List(items)
+            if items.len() == arity
+                && !items
+                    .iter()
+                    .any(|item| matches!(item.kind, hir::PatKind::Rest(_))) =>
+        {
+            items.get(index)
+        }
+        _ => None,
+    }
+}
+
+fn infer_match_lowered_param_ty(
+    decl: &hir::FunctionDeclaration,
+    body_expr: &hir::Expr,
+    index: usize,
+    param_hir_id: tlang_span::HirId,
+    type_table: &TypeTable,
+) -> Option<TyKind> {
+    match &body_expr.kind {
+        hir::ExprKind::Match(_, arms, _) => {
+            let arity = decl.parameters.len();
+            let mut inferred: Option<TyKind> = None;
+
+            for arm in arms {
+                let Some(column_pat) = match_lowered_param_pat(&arm.pat, index, arity) else {
+                    return None;
+                };
+                let Some(candidate) = infer_match_lowered_pat_ty(column_pat, type_table) else {
+                    continue;
+                };
+
+                if let Some(existing) = &inferred {
+                    if *existing != candidate {
+                        return None;
+                    }
+                } else {
+                    inferred = Some(candidate);
+                }
+            }
+
+            inferred
+        }
+        hir::ExprKind::IfElse(condition, _, else_clauses) => {
+            let mut inferred = infer_match_lowered_if_enum_ty(condition, param_hir_id, type_table);
+
+            for else_clause in else_clauses {
+                let Some(condition) = &else_clause.condition else {
+                    continue;
+                };
+                let candidate = infer_match_lowered_if_enum_ty(condition, param_hir_id, type_table);
+                match (&inferred, candidate) {
+                    (Some(existing), Some(candidate)) if *existing != candidate => return None,
+                    (None, Some(candidate)) => inferred = Some(candidate),
+                    _ => {}
+                }
+            }
+
+            inferred
+        }
+        _ => None,
+    }
+}
+
+fn infer_match_lowered_pat_ty(pat: &hir::Pat, type_table: &TypeTable) -> Option<TyKind> {
+    match &pat.kind {
+        hir::PatKind::Identifier(..) | hir::PatKind::Wildcard | hir::PatKind::Rest(_) => None,
+        hir::PatKind::Literal(lit) => Some(match lit.as_ref() {
+            Literal::Integer(_) | Literal::UnsignedInteger(_) => TyKind::Primitive(PrimTy::I64),
+            Literal::Float(_) => TyKind::Primitive(PrimTy::F64),
+            Literal::Boolean(_) => TyKind::Primitive(PrimTy::Bool),
+            Literal::String(_) => TyKind::Primitive(PrimTy::String),
+            Literal::Char(_) => TyKind::Primitive(PrimTy::Char),
+            Literal::None => TyKind::Primitive(PrimTy::Nil),
+        }),
+        hir::PatKind::List(_) => Some(TyKind::List(Box::new(hir::Ty::unknown()))),
+        hir::PatKind::Enum(path, _) => type_table.get(&path.res.hir_id()?).map(|info| match &info
+            .ty
+            .kind
+        {
+            TyKind::Fn(_, ret) => ret.kind.clone(),
+            kind => kind.clone(),
+        }),
+    }
+}
+
+fn infer_match_lowered_if_enum_ty(
+    expr: &hir::Expr,
+    param_hir_id: tlang_span::HirId,
+    type_table: &TypeTable,
+) -> Option<TyKind> {
+    match &expr.kind {
+        hir::ExprKind::Binary(op, lhs, rhs) => match op {
+            BinaryOpKind::Eq | BinaryOpKind::NotEq => {
+                match (
+                    condition_expr_targets_param(lhs, param_hir_id),
+                    condition_expr_variant_ty(rhs, type_table),
+                    condition_expr_targets_param(rhs, param_hir_id),
+                    condition_expr_variant_ty(lhs, type_table),
+                ) {
+                    (true, Some(candidate), _, _) | (_, _, true, Some(candidate)) => {
+                        Some(candidate)
+                    }
+                    _ => None,
+                }
+            }
+            BinaryOpKind::And | BinaryOpKind::Or => {
+                let lhs_ty = infer_match_lowered_if_enum_ty(lhs, param_hir_id, type_table);
+                let rhs_ty = infer_match_lowered_if_enum_ty(rhs, param_hir_id, type_table);
+                match (lhs_ty, rhs_ty) {
+                    (Some(lhs), Some(rhs)) if lhs != rhs => None,
+                    (Some(lhs), _) => Some(lhs),
+                    (_, Some(rhs)) => Some(rhs),
+                    _ => None,
+                }
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn condition_expr_targets_param(expr: &hir::Expr, param_hir_id: tlang_span::HirId) -> bool {
+    match &expr.kind {
+        hir::ExprKind::Path(path) => path.res.hir_id() == Some(param_hir_id),
+        hir::ExprKind::FieldAccess(base, _) => condition_expr_targets_param(base, param_hir_id),
+        _ => false,
+    }
+}
+
+fn condition_expr_variant_ty(expr: &hir::Expr, type_table: &TypeTable) -> Option<TyKind> {
+    let hir::ExprKind::Path(path) = &expr.kind else {
+        return None;
+    };
+
+    type_table
+        .get(&path.res.hir_id()?)
+        .map(|info| match &info.ty.kind {
+            TyKind::Fn(_, ret) => ret.kind.clone(),
+            kind => kind.clone(),
+        })
 }
 
 fn unary_op_str(op: UnaryOp) -> &'static str {
@@ -5366,6 +5631,7 @@ mod tests {
     fn protocol_dispatch_parts_requires_known_protocol_method() {
         let mut checker = TypeChecker::new();
         checker.type_table.insert_protocol_info(ProtocolInfo {
+            hir_id: None,
             name: Ident::new("Functor", tlang_span::Span::default()),
             type_param_var_ids: Vec::new(),
             methods: vec![ProtocolMethodInfo {
@@ -5402,6 +5668,7 @@ mod tests {
     fn visit_dispatch_receiver_arg_requires_known_protocol_dispatch_site() {
         let mut checker = TypeChecker::new();
         checker.type_table.insert_protocol_info(ProtocolInfo {
+            hir_id: None,
             name: Ident::new("Functor", tlang_span::Span::default()),
             type_param_var_ids: Vec::new(),
             methods: vec![ProtocolMethodInfo {

--- a/crates/tlang_typeck/src/type_checker.rs
+++ b/crates/tlang_typeck/src/type_checker.rs
@@ -3862,9 +3862,7 @@ fn infer_match_lowered_param_ty(
             let mut inferred: Option<TyKind> = None;
 
             for arm in arms {
-                let Some(column_pat) = match_lowered_param_pat(&arm.pat, index, arity) else {
-                    return None;
-                };
+                let column_pat = match_lowered_param_pat(&arm.pat, index, arity)?;
                 let Some(candidate) = infer_match_lowered_pat_ty(column_pat, type_table) else {
                     continue;
                 };

--- a/crates/tlang_typeck/src/type_checker.rs
+++ b/crates/tlang_typeck/src/type_checker.rs
@@ -1302,19 +1302,51 @@ impl TypeChecker {
             .iter()
             .find(|candidate| candidate.name.as_str() == method_name)?;
         let bounds = self.type_table.get_type_param_bounds(*type_var_id)?;
-        let bound = bounds.iter().find(|bound| {
-            self.type_table
-                .resolve_protocol_bound(bound)
-                .is_some_and(|(bound_protocol, _)| bound_protocol.hir_id == proto_info.hir_id)
-        })?;
 
-        let mut type_bindings = HashMap::new();
-        if let TyKind::Path(_, type_args) = &bound.kind {
-            for (proto_type_param, type_arg) in proto_info.type_param_var_ids.iter().zip(type_args)
-            {
-                type_bindings.insert(*proto_type_param, type_arg.kind.clone());
+        // Walk the direct bounds and their transitive constraint chains to find
+        // one whose protocol matches `proto_info`.  This handles cases such as
+        // `T: Ord` enabling dispatch to `Eq::…` because `Ord : Eq`.
+        let mut type_bindings = None;
+        'outer: for bound in bounds {
+            let Some((bound_protocol, _)) = self.type_table.resolve_protocol_bound(bound) else {
+                continue;
+            };
+
+            let mut initial_type_bindings = HashMap::new();
+            if let TyKind::Path(_, type_args) = &bound.kind {
+                for (proto_type_param, type_arg) in
+                    bound_protocol.type_param_var_ids.iter().zip(type_args)
+                {
+                    initial_type_bindings.insert(*proto_type_param, type_arg.kind.clone());
+                }
+            }
+
+            let mut visited = HashSet::new();
+            let mut stack = vec![(bound_protocol, initial_type_bindings)];
+            while let Some((candidate_protocol, candidate_type_bindings)) = stack.pop() {
+                if !visited.insert(candidate_protocol.hir_id) {
+                    continue;
+                }
+
+                if candidate_protocol.hir_id == proto_info.hir_id {
+                    type_bindings = Some(candidate_type_bindings);
+                    break 'outer;
+                }
+
+                for constraint_name in &candidate_protocol.constraints {
+                    let Some(constraint_protocol) =
+                        self.type_table.get_protocol_info(constraint_name)
+                    else {
+                        continue;
+                    };
+                    // Constraints are stored as bare names without type args, so
+                    // we carry the parent's bindings forward unchanged.
+                    stack.push((constraint_protocol, candidate_type_bindings.clone()));
+                }
             }
         }
+
+        let type_bindings = type_bindings?;
 
         let mut param_tys: Vec<Ty> = method
             .param_tys
@@ -3790,7 +3822,16 @@ impl TypeChecker {
     }
 }
 
-fn match_lowered_param_pat(pat: &hir::Pat, index: usize, arity: usize) -> Option<&hir::Pat> {
+/// Extract the pattern for a single parameter column from a lowered match arm.
+///
+/// Multi-clause functions are lowered to a match with a list scrutinee that
+/// packs all parameters together.  This helper recovers the sub-pattern at
+/// position `index` for a given `arity`.
+///
+/// - When `arity == 1` the arm's pattern *is* the single parameter pattern.
+/// - When `arity > 1` the arm's pattern is a `PatKind::List` of exactly
+///   `arity` non-rest items; this returns the item at `index`.
+pub fn match_lowered_param_pat(pat: &hir::Pat, index: usize, arity: usize) -> Option<&hir::Pat> {
     if arity == 1 {
         return Some(pat);
     }

--- a/crates/tlang_typeck/src/type_table.rs
+++ b/crates/tlang_typeck/src/type_table.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
 use tlang_ast::node::Ident;
-use tlang_hir::Ty;
+use tlang_hir::{Ty, TyKind};
 use tlang_span::HirId;
 use tlang_span::TypeVarId;
+
+use crate::builtin_protocols;
 
 /// Supplementary type metadata for a given HIR node.
 ///
@@ -59,6 +61,7 @@ pub struct AssociatedTypeInfo {
 /// constraint protocols.
 #[derive(Debug, Clone)]
 pub struct ProtocolInfo {
+    pub hir_id: Option<HirId>,
     pub name: Ident,
     pub type_param_var_ids: Vec<TypeVarId>,
     pub methods: Vec<ProtocolMethodInfo>,
@@ -99,8 +102,12 @@ pub struct TypeTable {
     enum_info: HashMap<HirId, EnumInfo>,
     /// Protocol declarations keyed by the protocol name.
     protocol_info: HashMap<String, ProtocolInfo>,
+    /// Protocol declarations keyed by their lowered `HirId` when available.
+    protocol_info_by_hir_id: HashMap<HirId, ProtocolInfo>,
     /// Registered impl blocks.
     impl_info: Vec<ImplInfo>,
+    /// Constraint bounds recorded for lowered type variables.
+    type_param_bounds: HashMap<TypeVarId, Vec<Ty>>,
 }
 
 impl TypeTable {
@@ -164,6 +171,9 @@ impl TypeTable {
 
     /// Register protocol declaration metadata.
     pub fn insert_protocol_info(&mut self, info: ProtocolInfo) {
+        if let Some(hir_id) = info.hir_id {
+            self.protocol_info_by_hir_id.insert(hir_id, info.clone());
+        }
         self.protocol_info.insert(info.name.to_string(), info);
     }
 
@@ -172,9 +182,48 @@ impl TypeTable {
         self.protocol_info.get(name)
     }
 
+    /// Look up protocol info by declaration `HirId`.
+    pub fn get_protocol_info_by_hir_id(&self, hir_id: HirId) -> Option<&ProtocolInfo> {
+        self.protocol_info_by_hir_id.get(&hir_id)
+    }
+
+    /// Resolve a protocol-bound type annotation to the registered protocol info
+    /// plus its type arguments.
+    pub fn resolve_protocol_bound<'a>(
+        &'a self,
+        bound: &'a Ty,
+    ) -> Option<(&'a ProtocolInfo, &'a [Ty])> {
+        let TyKind::Path(path, type_args) = &bound.kind else {
+            return None;
+        };
+
+        let protocol = path
+            .res
+            .hir_id()
+            .or(bound.res)
+            .and_then(|hir_id| self.get_protocol_info_by_hir_id(hir_id))
+            .or_else(|| {
+                builtin_protocols::builtin_hir_id(&path.join("::"))
+                    .and_then(|hir_id| self.get_protocol_info_by_hir_id(hir_id))
+            })
+            .or_else(|| self.get_protocol_info(&path.join("::")))?;
+
+        Some((protocol, type_args.as_slice()))
+    }
+
     /// Register an impl block.
     pub fn insert_impl_info(&mut self, info: ImplInfo) {
         self.impl_info.push(info);
+    }
+
+    /// Register the bounds attached to a lowered type variable.
+    pub fn insert_type_param_bounds(&mut self, type_var_id: TypeVarId, bounds: Vec<Ty>) {
+        self.type_param_bounds.insert(type_var_id, bounds);
+    }
+
+    /// Look up the declared bounds for a lowered type variable.
+    pub fn get_type_param_bounds(&self, type_var_id: TypeVarId) -> Option<&[Ty]> {
+        self.type_param_bounds.get(&type_var_id).map(Vec::as_slice)
     }
 
     /// Return all registered impl blocks.

--- a/crates/tlang_typeck/tests/type_checker.rs
+++ b/crates/tlang_typeck/tests/type_checker.rs
@@ -1430,6 +1430,17 @@ fn protocol_method_call_with_return_type_propagates() {
     );
 }
 
+#[test]
+fn constrained_generic_protocol_method_call_typechecks() {
+    common::typecheck_ok(
+        r#"
+        fn print<T: Display>(value: T) {
+            log(value.to_string())
+        }
+        "#,
+    );
+}
+
 // ── Default method bodies ───────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- lower method calls on protocol-constrained generics into explicit protocol dispatch
- preserve analysis/LSP support for hover, completion, and goto on those calls
- split the JS-target optimization pipeline so exhaustive enum cleanup still runs on the right shape